### PR TITLE
Add example about the usage of LuaType.GetType()

### DIFF
--- a/doc/05_01_clr.md
+++ b/doc/05_01_clr.md
@@ -121,6 +121,25 @@ const StringBuilder typeof System.Text.StringBuilder;
 local sb : StringBuilder = StringBuilder("Hello ");
 ```
 
+###### Example mapping in host application
+
+Besides using Lua to access framework types and namespace you can also map these in the host application like this:
+
+```C#
+using (Lua l = new Lua())
+{
+  var g = l.CreateEnvironment();
+  dynamic dg = g;
+  
+  dg.customTable = new LuaTable();
+  dg.customTable.env = LuaType.GetType(typeof(System.Environment));
+}
+```
+
+```Lua
+print(customTable.env.GetEnvironmentVariable("TEMP"));
+```
+
 ## Instance methods
 
 Methods can also called through a member call or you can get the reference to the member.


### PR DESCRIPTION
Added an example about how to map a .net framwork type or namespace in the host application to a custom table.
See #83 for details.