### PR TITLE
Added a way to disable the clr object

### DIFF
--- a/NeoCmd/Program.cs
+++ b/NeoCmd/Program.cs
@@ -198,7 +198,7 @@ namespace Neo.IronLua
 		private static Lua lua = new Lua(); // create lua script compiler
 		private static LuaGlobal global;
 		private static ILuaDebug debugEngine = LuaStackTraceDebugger.Default;
-		private static bool ClrEnabled = true;
+		private static bool clrEnabled = true;
 		private static readonly ILuaDebug debugConsole = new LuaTraceLineConsoleDebugger();
 
 		private static void WriteText(ConsoleColor textColor, string text)
@@ -456,7 +456,7 @@ namespace Neo.IronLua
 				sw.Start();
 
 				// compile chunk
-				var c = lua.CompileChunk(code(), name, new LuaCompileOptions() { DebugEngine = debugEngine, ClrEnabled = ClrEnabled });
+				var c = lua.CompileChunk(code(), name, new LuaCompileOptions() { DebugEngine = debugEngine, ClrEnabled = clrEnabled });
 
 				var compileTime = String.Format("{0:N0} ms", sw.ElapsedMilliseconds);
 				sw.Reset();
@@ -606,13 +606,13 @@ namespace Neo.IronLua
 						Console.WriteLine();
 						break;
 					case Commands.ClrOn:
-						ClrEnabled = true;
+						clrEnabled = true;
 						WriteText(ConsoleColor.DarkYellow, "Clr access enabled."); Console.WriteLine();
 						Console.WriteLine();
 						break;
 					case Commands.ClrOff:
 						WriteText(ConsoleColor.DarkYellow, "Clr access disabled."); Console.WriteLine();
-						ClrEnabled = false;
+						clrEnabled = false;
 						Console.WriteLine();
 						break;
 					case Commands.Help:

--- a/NeoCmd/Program.cs
+++ b/NeoCmd/Program.cs
@@ -42,7 +42,9 @@ namespace Neo.IronLua
 			Debug,
 			Environment,
 			Cache,
-			Help
+			Help,
+			ClrOn,
+			ClrOff
 		} // enum Commands
 
 		#endregion
@@ -196,6 +198,7 @@ namespace Neo.IronLua
 		private static Lua lua = new Lua(); // create lua script compiler
 		private static LuaGlobal global;
 		private static ILuaDebug debugEngine = LuaStackTraceDebugger.Default;
+		private static bool ClrEnabled = true;
 		private static readonly ILuaDebug debugConsole = new LuaTraceLineConsoleDebugger();
 
 		private static void WriteText(ConsoleColor textColor, string text)
@@ -351,6 +354,16 @@ namespace Neo.IronLua
 						line = command.Substring(6).Trim();
 						return Commands.Cache;
 					}
+					else if (command.StartsWith(":clron", StringComparison.OrdinalIgnoreCase))
+					{
+						line = command.Substring(6).Trim();
+						return Commands.ClrOn;
+					}
+					else if (command.StartsWith(":clroff", StringComparison.OrdinalIgnoreCase))
+					{
+						line = command.Substring(7).Trim();
+						return Commands.ClrOff;
+					}
 					else if (command.StartsWith(":c", StringComparison.OrdinalIgnoreCase))
 					{
 						sbLine.Clear();
@@ -443,7 +456,7 @@ namespace Neo.IronLua
 				sw.Start();
 
 				// compile chunk
-				var c = lua.CompileChunk(code(), name, new LuaCompileOptions() { DebugEngine = debugEngine });
+				var c = lua.CompileChunk(code(), name, new LuaCompileOptions() { DebugEngine = debugEngine, ClrEnabled = ClrEnabled });
 
 				var compileTime = String.Format("{0:N0} ms", sw.ElapsedMilliseconds);
 				sw.Reset();
@@ -592,6 +605,16 @@ namespace Neo.IronLua
 						lua.DumpRuleCaches(Console.Out);
 						Console.WriteLine();
 						break;
+					case Commands.ClrOn:
+						ClrEnabled = true;
+						WriteText(ConsoleColor.DarkYellow, "Clr access enabled."); Console.WriteLine();
+						Console.WriteLine();
+						break;
+					case Commands.ClrOff:
+						WriteText(ConsoleColor.DarkYellow, "Clr access disabled."); Console.WriteLine();
+						ClrEnabled = false;
+						Console.WriteLine();
+						break;
 					case Commands.Help:
 						WriteText(ConsoleColor.DarkYellow, "Commands:"); Console.WriteLine();
 						WriteCommand(":q", "Exit the application.");
@@ -604,6 +627,8 @@ namespace Neo.IronLua
 						WriteCommand(":c", "Clears the current script buffer.");
 						WriteCommand(":env", "Create a fresh environment.");
 						WriteCommand(":cache", "Shows the content of the binder cache.");
+						WriteCommand(":clron", "Enables access to the clr.");
+						WriteCommand(":clroff", "Disables access to the clr.");
 						Console.WriteLine();
 						break;
 					case Commands.Run:

--- a/NeoLua.Test/Parser.cs
+++ b/NeoLua.Test/Parser.cs
@@ -290,6 +290,54 @@ namespace LuaDLR.Test
 			);
 		}
 
+		[TestMethod]
+		public void TestClrDisabled()
+		{
+			string code = "return type(clr) == type(nil);";
+			using (var l = new Lua())
+			{
+				l.PrintExpressionTree = PrintExpressionTree ? Console.Out : null;
+				var g = l.CreateEnvironment<LuaGlobal>();
+				g.DefaultCompileOptions = new LuaCompileOptions()
+				{
+					ClrEnabled = false
+				};
+				Console.WriteLine("Test: {0}", code);
+				Console.WriteLine(new string('=', 66));
+				var sw = new Stopwatch();
+				sw.Start();
+				TestResult(g.DoChunk(code, "test.lua"), true);
+				Console.WriteLine("  Dauer: {0}ms", sw.ElapsedMilliseconds);
+				Console.WriteLine();
+				Console.WriteLine();
+			}
+		}
+
+		[TestMethod]
+		public void TestClrEnabled()
+		{
+			// As the type of the clr object could change, let's air on the side of safety
+			// and only check if it exists as it could be anything
+			string code = "return type(clr) == type(nil);";
+			using (var l = new Lua())
+			{
+				l.PrintExpressionTree = PrintExpressionTree ? Console.Out : null;
+				var g = l.CreateEnvironment<LuaGlobal>();
+				g.DefaultCompileOptions = new LuaCompileOptions()
+				{
+					ClrEnabled = true
+				};
+				Console.WriteLine("Test: {0}", code);
+				Console.WriteLine(new string('=', 66));
+				var sw = new Stopwatch();
+				sw.Start();
+				TestResult(g.DoChunk(code, "test.lua"), false);
+				Console.WriteLine("  Dauer: {0}ms", sw.ElapsedMilliseconds);
+				Console.WriteLine();
+				Console.WriteLine();
+			}
+		}
+
 		#endregion
 
 		#region -- Test Position ------------------------------------------------------

--- a/NeoLua/Lua.cs
+++ b/NeoLua/Lua.cs
@@ -124,6 +124,8 @@ namespace Neo.IronLua
 		public Func<object, object> DynamicSandbox { get; set; }
 		/// <summary>Set this member to compile the script with Debug-Infos.</summary>
 		public ILuaDebug DebugEngine { get; set; }
+		/// <summary>Wether or not to recognize the local</summary>
+		public bool ClrEnabled { get; set; } = true;
 	} // class LuaCompileOptions
 
 	#endregion

--- a/NeoLua/Parser.cs
+++ b/NeoLua/Parser.cs
@@ -1147,7 +1147,6 @@ namespace Neo.IronLua
 				case LuaToken.KwForEach:
 				case LuaToken.KwConst:
 					var t = code.Current;
-					if (t.Value == csClr) // clr is a special package, that always exists
 					{
 						code.Next();
 						info = new PrefixMemberInfo(tStart, Expression.Property(null, Lua.TypeClrPropertyInfo), null, null, null);

--- a/NeoLua/Parser.cs
+++ b/NeoLua/Parser.cs
@@ -1147,6 +1147,7 @@ namespace Neo.IronLua
 				case LuaToken.KwForEach:
 				case LuaToken.KwConst:
 					var t = code.Current;
+					if (scope.Options.ClrEnabled && t.Value == csClr) // clr is a special package, that always exists if it's enabled (it's on by default)
 					{
 						code.Next();
 						info = new PrefixMemberInfo(tStart, Expression.Property(null, Lua.TypeClrPropertyInfo), null, null, null);

--- a/doc/05_01_clr.md
+++ b/doc/05_01_clr.md
@@ -285,7 +285,6 @@ If you want to disable access to the clr library, you can do so by setting `ClrE
 ```C#
 using (var l = new Lua())
 {
-	l.PrintExpressionTree = PrintExpressionTree ? Console.Out : null;
 	var g = l.CreateEnvironment<LuaGlobal>();
 	g.DefaultCompileOptions = new LuaCompileOptions()
 	{

--- a/doc/05_01_clr.md
+++ b/doc/05_01_clr.md
@@ -279,3 +279,19 @@ It is also possible to call this function from a lua script.
 clr.Neo.IronLua.LuaType:RegisterTypeExtension(clr.Some.Extension.Type);
 ```
 
+## Disabling clr access
+
+If you want to disable access to the clr library, you can do so by setting `ClrEnabled` to false in the compile options.
+```C#
+using (var l = new Lua())
+{
+	l.PrintExpressionTree = PrintExpressionTree ? Console.Out : null;
+	var g = l.CreateEnvironment<LuaGlobal>();
+	g.DefaultCompileOptions = new LuaCompileOptions()
+	{
+		ClrEnabled = false
+	};
+	// With ClrEnabled set to false, this should return false;
+	g.DoChunk("print('Clr Access is: ' .. (type(clr) == type(nil) and 'Disabled' or 'Enabled'));", "test.lua");
+}
+```


### PR DESCRIPTION
Summary of changes:
For security reasons, I need a way to disable the CLR functionality. To achieve this goal, I added a new parameter to the `LuaCompileOptions` class called `ClrEnabled`. To preserve existing functionality, `ClrEnabled` is set to true by default. I've also added ways to test this new functionality through the unit tests and via the `NeoCmd` utility: I've also added a  new section at the bottom of the CLR documentation file to explain how disabling CLR works.

List of changes:
* Added a new parameter called `ClrEnabled` to the `LuaCompileOptions` class (set to true by default).
* Added a check for the `ClrEnabled` option in the `ParsePrefix` function of the `Parser` class.
* Added `TestClrEnabled` and `TestClrDisabled` in the `Parser.cs` unit test file.
* Added the `:clron` and `clroff` to the `NeoCmd` utility.
* Added documentation for the new `NeoCmd` commands.
* Added documentation for the new `ClrEnabled` parameter in the `CLR` documentation file.