### PR TITLE
Allow forward declaration of local function

### DIFF
--- a/NeoLua.Test/Functions.cs
+++ b/NeoLua.Test/Functions.cs
@@ -403,6 +403,22 @@ namespace LuaDLR.Test
 		}
 
 		[TestMethod]
+		public void TestAssignFunctionToParentLocal()
+		{
+			TestCode(@"
+local f
+function g()
+	function f()
+		return 'Hello'
+	end
+end
+g()
+return f()
+",
+"Hello");
+		}
+
+		[TestMethod]
 		public void TestFunctionConvert01()
 		{
 			var f = new TestDelegateConvert();

--- a/NeoLua.Test/Functions.cs
+++ b/NeoLua.Test/Functions.cs
@@ -361,6 +361,48 @@ namespace LuaDLR.Test
 		}
 
 		[TestMethod]
+		public void TestForwardDeclaration()
+		{
+			TestCode(
+			@"local f
+			function f()
+				return 'Hello'
+			end
+
+			return f()",
+			"Hello");
+		}
+		[TestMethod]
+		public void TestDoubleLocalFunction()
+		{
+			TestCode(
+			@"local function f()
+				return 'Hello'
+			end
+			local function f()
+				return 'World'
+			end
+			return f()",
+			"World");
+		}
+
+		[TestMethod]
+		public void TestLocalMutualRecursiveFunction()
+		{
+			TestCode(
+			@"
+			local f1, f2
+			function f2()
+				return f1()
+			end
+			function f1()
+				return 'Hello'
+			end
+			return _G['f2'] == nil",
+			true);
+		}
+
+		[TestMethod]
 		public void TestFunctionConvert01()
 		{
 			var f = new TestDelegateConvert();

--- a/NeoLua/Parser.cs
+++ b/NeoLua/Parser.cs
@@ -2181,7 +2181,7 @@ namespace Neo.IronLua
 			{
 				var t = FetchToken(LuaToken.Identifier, code);
 
-				ParameterExpression funcVar = scope.LookupExpression(t.Value, true) as ParameterExpression;
+				ParameterExpression funcVar = scope.LookupExpression(t.Value) as ParameterExpression;
 				Expression exprFunction;
 				if (funcVar == null)
 				{
@@ -2227,8 +2227,8 @@ namespace Neo.IronLua
 					if (assignee == null)
 					{
 						// there was no member access, so try to find a local to assign to
-						var local = scope.LookupExpression(memberName, true);
-						if (local != null)
+						var local = scope.LookupExpression(memberName);
+						if (local is ParameterExpression)
 						{
 							scope.AddExpression(Expression.Assign(local, ParseLamdaDefinition(scope, code, memberName, false, null)));
 							return;


### PR DESCRIPTION
Hi @neolithos 

I had some problems with forward-declaration of local functions like this:

```lua
    local f
    function f()
        return 'Hello'
    end

    print(f()) -- expected 'Hello'; 'Can not call nil value' exception in NeoLua
```

This is required to support local mutual recursion. Similar code is given as an example in [Programming in Lua](https://www.lua.org/pil/6.2.html) and this seems to work ok in luac 5.3.3: https://www.ideone.com/JD0aKj

I think I have fixed this by being able to assign to an existing local when parsing a `function` statement.

This change also means that local functions can be redeclared, which wasn't possible before:

```lua
	local function f()
		return 'Hello'
	end
	local function f()
		return 'World'
	end
	print(f()) -- expected 'World'; NeoLua fails to compile
```

Now a `function` statement will not escape into the global scope if we have a local:

```lua
    	local f1, f2
    	function f2()
    		return f1()
    	end
    	function f1()
    		return 'Hello'
    	end
    	return _G['f2'] == nil -- expected 'true'; NeoLua returns 'false'
```

The only thing I'm not sure about is if it is correct to pass `true` to `scope.LookupExpression`, or whether we could also bind to a local in a deeper scope.

Thank you @neolithos for your work on this excellent project!

best regards

Oliver