### PR TITLE
Bugfix for Assembly.ReflectionOnlyLoad under .Net 5+ and expose faster assembly load option

### DIFF
--- a/NeoLua.Dbg/NeoLua.Dbg.csproj
+++ b/NeoLua.Dbg/NeoLua.Dbg.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Neo.Lua.Dbg</AssemblyName>
 		<RootNamespace>Neo.IronLua</RootNamespace>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<TargetFrameworks>net45;netcoreapp2.1</TargetFrameworks>
+		<TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>NeoLua.snk</AssemblyOriginatorKeyFile>
 		<PackageId>NeoLuaDebug</PackageId>

--- a/NeoLua.NuGet/common.targets
+++ b/NeoLua.NuGet/common.targets
@@ -12,9 +12,9 @@
 		<RepositoryType>git</RepositoryType>
 		
 		<AssemblyVersion>5.3.0.0</AssemblyVersion>
-		<FileVersion>1.3.14.0</FileVersion>
+		<FileVersion>1.4.0.0</FileVersion>
 
-		<!--<VersionAdd>beta.0</VersionAdd>-->
+		<VersionAdd>beta.0</VersionAdd>
 		<SimpleVersionPattern>^(\d+)\.(\d+)\.(\d+)</SimpleVersionPattern>
 		<SimpleVersion>$([System.Text.RegularExpressions.Regex]::Match($(FileVersion), $(SimpleVersionPattern)))</SimpleVersion>
 

--- a/NeoLua.Test/ControlStructures.cs
+++ b/NeoLua.Test/ControlStructures.cs
@@ -363,6 +363,12 @@ namespace LuaDLR.Test
 		}
 
 		[TestMethod]
+		public void Control20()
+		{
+			TestCode(GetLines("Lua.Control20.lua"), 500000500000, 500000500001);
+		}
+
+		[TestMethod]
 		public void TestVariableAssign01()
 		{
 			TestCode(Lines(

--- a/NeoLua.Test/Lua/Control20.lua
+++ b/NeoLua.Test/Lua/Control20.lua
@@ -1,0 +1,8 @@
+﻿local t = {};
+local j = 1;
+for i = 500000500000, 500000500001 do
+	print(tostring(i));
+	t[j] = i; 
+	j = j + 1;
+end;
+return t[1], t[2];

--- a/NeoLua.Test/LuaTable.cs
+++ b/NeoLua.Test/LuaTable.cs
@@ -13,9 +13,11 @@ namespace LuaDLR.Test
 	{
 		#region -- class ObjectInit ---------------------------------------------------
 
+		public const string ObjectInitLua = "";
+
 		public class ObjectInit
 		{
-			private object[] values = new object[10];
+			private readonly object[] values = new object[10];
 
 			public void TestEvent()
 			{
@@ -428,7 +430,11 @@ namespace LuaDLR.Test
 		#region -- TestConvert ------------------------------------------------------------
 
 		[TestMethod]
-		public void TestConvert01()
+		public void TestConvert01a()
+			=> TestCode("return cast(LuaDLR.Test.LuaTypeTests.SubStruct, { Value = 2 }).Value", 2);
+
+		[TestMethod]
+		public void TestConvert01b()
 		{
 			using (var l = new Lua())
 			{

--- a/NeoLua.Test/LuaType.cs
+++ b/NeoLua.Test/LuaType.cs
@@ -499,19 +499,13 @@ namespace LuaDLR.Test
 		}
 
 		[TestMethod]
-		public void CtorTest03()
-		{
-			TestCode("return cast(LuaDLR.Test.LuaTypeTests.SubStruct, { Value = 2 }).Value", 2);
-		}
-
-		[TestMethod]
 		public void CtorTest10()
 		{
 			using (var l = new Lua())
 			{
 				l.PrintExpressionTree = Console.Out;
 				var g = l.CreateEnvironment();
-				var r = g.DoChunk("return clr.LuaDLR.Test.LuaTableTests.ObjectInit{ Value = 42, 1, 2, 3 };", "dummy");
+				var r = g.DoChunk("return clr.LuaDLR.Test.LuaTableTests.ObjectInit(){ Value = 42, 1, 2, 3 };", "dummy");
 				var o = (ObjectInit)r[0];
 				Assert.AreEqual(o.Value, 42);
 				Assert.AreEqual(o[0], 1);

--- a/NeoLua.Test/LuaType.cs
+++ b/NeoLua.Test/LuaType.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.IronLua;
+using static LuaDLR.Test.LuaTableTests;
 
 namespace LuaDLR.Test
 {
@@ -35,6 +34,9 @@ namespace LuaDLR.Test
 		public class DataTypeTest
 		{
 			public Type DataType;
+
+			public static explicit operator DataTypeTest(LuaTable t)
+				=> t.SetObjectMember(new DataTypeTest());
 		}
 
 		public class Graph
@@ -308,14 +310,14 @@ namespace LuaDLR.Test
 		public void TypeTest08()
 		{
 			TestCode(Lines("local t : System.Type = clr.System.Text.StringBuilder;",
-				"return t"), typeof(System.Text.StringBuilder));
+				"return t"), typeof(StringBuilder));
 		}
 
 		[TestMethod]
 		public void TypeTest09()
 		{
 			TestCode(Lines("local t : LuaDLR.Test.LuaTypeTests.DataTypeTest = { DataType = clr.System.Text.StringBuilder };",
-				"return t.DataType"), typeof(System.Text.StringBuilder));
+				"return t.DataType"), typeof(StringBuilder));
 		}
 
 		[TestMethod]
@@ -500,6 +502,35 @@ namespace LuaDLR.Test
 		public void CtorTest03()
 		{
 			TestCode("return cast(LuaDLR.Test.LuaTypeTests.SubStruct, { Value = 2 }).Value", 2);
+		}
+
+		[TestMethod]
+		public void CtorTest10()
+		{
+			using (var l = new Lua())
+			{
+				l.PrintExpressionTree = Console.Out;
+				var g = l.CreateEnvironment();
+				var r = g.DoChunk("return clr.LuaDLR.Test.LuaTableTests.ObjectInit{ Value = 42, 1, 2, 3 };", "dummy");
+				var o = (ObjectInit)r[0];
+				Assert.AreEqual(o.Value, 42);
+				Assert.AreEqual(o[0], 1);
+				Assert.AreEqual(o[1], 2);
+				Assert.AreEqual(o[2], 3);
+			}
+		}
+
+		[TestMethod]
+		public void CtorTest11()
+		{
+			using (var l = new Lua())
+			{
+				l.PrintExpressionTree = Console.Out;
+				var g = l.CreateEnvironment();
+				var r = g.DoChunk("return clr.LuaDLR.Test.LuaTableTests.ObjectInitS{ Value = 42, 1, 2, 3 };", "dummy");
+				var o = (ObjectInitS)r[0];
+				Assert.AreEqual(o.Value, 42);
+			}
 		}
 
 		[TestMethod]

--- a/NeoLua.Test/NeoLua.Test.csproj
+++ b/NeoLua.Test/NeoLua.Test.csproj
@@ -25,6 +25,7 @@
 	  <None Remove="Lua\Control11.lua" />
 	  <None Remove="Lua\Control12.lua" />
 	  <None Remove="Lua\Control19.lua" />
+	  <None Remove="Lua\Control20.lua" />
 	  <None Remove="Lua\Coroutines01.lua" />
 	  <None Remove="Lua\EnvDynamicCall01.lua" />
 	  <None Remove="Lua\Function08.lua" />
@@ -51,6 +52,7 @@
 	  <EmbeddedResource Include="Lua\Control11.lua" />
 	  <EmbeddedResource Include="Lua\Control12.lua" />
 	  <EmbeddedResource Include="Lua\Control19.lua" />
+	  <EmbeddedResource Include="Lua\Control20.lua" />
 	  <EmbeddedResource Include="Lua\Coroutines01.lua" />
 	  <EmbeddedResource Include="Lua\EnvDynamicCall01.lua" />
 	  <EmbeddedResource Include="Lua\Function08.lua" />

--- a/NeoLua.Test/RunLuaTests.cs
+++ b/NeoLua.Test/RunLuaTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.IronLua;
 

--- a/NeoLua.Test/Runtime.cs
+++ b/NeoLua.Test/Runtime.cs
@@ -283,7 +283,7 @@ namespace LuaDLR.Test
 		{
 			var t = new LuaTable();
 			t["DataType"] = typeof(StringBuilder);
-			var r = Lua.RtConvertValue(t, typeof(LuaDLR.Test.LuaTypeTests.DataTypeTest));
+			var r = Lua.RtConvertValue(t, typeof(LuaTypeTests.DataTypeTest));
 			Assert.AreEqual(typeof(LuaTypeTests.DataTypeTest), r.GetType());
 			Assert.AreEqual(typeof(StringBuilder), ((LuaTypeTests.DataTypeTest)r).DataType);
 		}

--- a/NeoLua/Lua.Runtime.cs
+++ b/NeoLua/Lua.Runtime.cs
@@ -185,7 +185,7 @@ namespace Neo.IronLua
 
 			TableDefineMethodLightMethodInfo = tiLuaTable.FindDeclaredMethod(nameof(LuaTable.DefineMethodLight), ReflectionFlag.None, typeof(string), typeof(Delegate));
 			TableGetCallMemberMethodInfo = tiLuaTable.FindDeclaredMethod(nameof(LuaTable.GetCallMember), ReflectionFlag.NoArguments);
-			TableSetObjectMemberMethodInfo = tiLuaTable.FindDeclaredMethod(nameof(LuaTable.SetObjectMember), ReflectionFlag.None, typeof(object));
+			TableSetObjectMemberMethodInfo = tiLuaTable.FindDeclaredMethod(nameof(LuaTable.SetObjectMember), ReflectionFlag.None, typeof(object), typeof(bool));
 
 			TableEntriesFieldInfo = tiLuaTable.FindDeclaredField("entries", ReflectionFlag.None);
 			TablePropertyChangedMethodInfo = tiLuaTable.FindDeclaredMethod("OnPropertyChanged", ReflectionFlag.None, typeof(string));

--- a/NeoLua/Lua.cs
+++ b/NeoLua/Lua.cs
@@ -547,7 +547,7 @@ namespace Neo.IronLua
 			}
 		} // prop Version
 
-#if !NETSTANDARD2_0 && !NETCOREAPP2_1 && !NET5_0
+#if !NETSTANDARD2_1 && !NETCOREAPP3_1 && !NET5_0
 		/// <summary>Stack trace compile options.</summary>
 		public static LuaCompileOptions StackTraceCompileOptions { get; } = new LuaCompileOptions { DebugEngine = LuaStackTraceDebugger.Default };
 #endif

--- a/NeoLua/LuaChunk.cs
+++ b/NeoLua/LuaChunk.cs
@@ -72,7 +72,7 @@ namespace Neo.IronLua
 			try
 			{
 				var r = chunk.DynamicInvoke(args);
-				return r is LuaResult ? (LuaResult)r : new LuaResult(r);
+				return r is LuaResult t ? t : new LuaResult(r);
 			}
 			catch (TargetInvocationException e)
 			{

--- a/NeoLua/LuaEmit.cs
+++ b/NeoLua/LuaEmit.cs
@@ -1798,6 +1798,13 @@ namespace Neo.IronLua
 					result = Expression.Assign(Expression.Field(target != null ? Lua.EnsureType(target, targetType) : null, fieldInfo), set(fieldInfo.FieldType));
 					return LuaTrySetMemberReturn.ValidExpression;
 				}
+				else if (memberInfo is EventInfo eventInfo)
+				{
+					result = target == null
+						? Expression.Call(eventInfo.AddMethod, set(eventInfo.EventHandlerType))
+						: Expression.Call(target, eventInfo.AddMethod, set(eventInfo.EventHandlerType));
+					return LuaTrySetMemberReturn.ValidExpression;
+				}
 				else
 				{
 					result = null;
@@ -1831,7 +1838,7 @@ namespace Neo.IronLua
 			if (isParse && IsDynamicType(instanceType))
 			{
 				return DynamicExpression.Dynamic(runtime.GetSetIndexMember(new CallInfo(arguments.Length)), typeof(object),
-					CreateDynamicArgs<TARG>(getExpr(instance), instanceType, arguments, setTo, getExpr, getType)
+					CreateDynamicArgs(getExpr(instance), instanceType, arguments, setTo, getExpr, getType)
 				);
 			}
 

--- a/NeoLua/LuaEmit.cs
+++ b/NeoLua/LuaEmit.cs
@@ -2769,7 +2769,7 @@ namespace Neo.IronLua
 				emitCall = convertedArguments => Expression.Call(null, methodInfo, convertedArguments);
 			}
 
-			result = BindParameter<TARG>(lua,
+			result = BindParameter(lua,
 				 emitCall,
 				 methodInfo.GetParameters(),
 				 callInfo,

--- a/NeoLua/LuaStackTraceDebugger.cs
+++ b/NeoLua/LuaStackTraceDebugger.cs
@@ -18,7 +18,7 @@
 // under the License.
 //
 #endregion
-#if !NETSTANDARD2_0 && !NETCOREAPP2_1 && !NET5_0
+#if !NETSTANDARD2_1 && !NETCOREAPP3_1 && !NET5_0
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;

--- a/NeoLua/LuaTable.cs
+++ b/NeoLua/LuaTable.cs
@@ -2800,7 +2800,7 @@ namespace Neo.IronLua
 		private static bool IsPublicMethod(MethodInfo methodInfo)
 			=> methodInfo != null && methodInfo.IsPublic && !methodInfo.IsStatic;
 
-		private static bool IsIndexSetter(PropertyInfo propertyInfo)
+		internal static bool IsIndexSetter(PropertyInfo propertyInfo)
 		{
 			var setMethod = propertyInfo.SetMethod;
 			if (IsPublicMethod(setMethod))
@@ -2823,20 +2823,6 @@ namespace Neo.IronLua
 				return true;
 			}
 		} // func TryGetMemberValue
-
-		/// <summary>Initialize an object with the current set of members.</summary>
-		/// <typeparam name="T"></typeparam>
-		/// <param name="strict">Only allows to set direct declared values.</param>
-		/// <returns>The new object</returns>
-		public T InitObject<T>(bool strict = false)
-			=> SetObjectMember(Activator.CreateInstance<T>(), strict);
-
-		/// <summary>Initialize an object with the current set of members.</summary>
-		/// <param name="type"></param>
-		/// <param name="strict">Only allows to set direct declared values.</param>
-		/// <returns>The new object</returns>
-		public object InitObject(Type type, bool strict = false)
-			=> SetObjectMember(Activator.CreateInstance(type), strict);
 
 		private object SetObjectArray(PropertyInfo indexProperty, object obj)
 		{
@@ -2930,6 +2916,20 @@ namespace Neo.IronLua
 			var type = obj.GetType();
 			return strict ? SetObjectMemberStrict(type, obj) : SetObjectMemberDynamic(type, obj);
 		} // func SetObjectMember
+
+		/// <summary>Initialize an object with the current set of members.</summary>
+		/// <typeparam name="T"></typeparam>
+		/// <param name="strict">Only allows to set direct declared values.</param>
+		/// <returns>The new object</returns>
+		public T InitObject<T>(bool strict = false)
+			=> SetObjectMember(Activator.CreateInstance<T>(), strict);
+
+		/// <summary>Initialize an object with the current set of members.</summary>
+		/// <param name="type"></param>
+		/// <param name="strict">Only allows to set direct declared values.</param>
+		/// <returns>The new object</returns>
+		public object InitObject(Type type, bool strict = false)
+			=> SetObjectMember(Activator.CreateInstance(type), strict);
 
 		#endregion
 
@@ -3969,7 +3969,7 @@ namespace Neo.IronLua
 		/// <param name="t"></param>
 		/// <param name="strict">Only allows to set direct declared values.</param>
 		/// <returns></returns>
-		public static object set(object obj, LuaTable t, bool strict)
+		public static object set(object obj, LuaTable t, bool strict = false)
 			=> t.SetObjectMember(obj, strict);
 
 		/// <summary>Initialize an object with the current set of members.</summary>
@@ -3977,7 +3977,7 @@ namespace Neo.IronLua
 		/// <param name="t"></param>
 		/// <param name="luaType"></param>
 		/// <returns>The new object</returns>
-		public static object @new(LuaTable t, LuaType luaType, bool strict)
+		public static object @new(LuaTable t, LuaType luaType, bool strict = false)
 			=> t.InitObject(luaType.Type, strict);
 
 		#endregion

--- a/NeoLua/LuaType.cs
+++ b/NeoLua/LuaType.cs
@@ -1419,7 +1419,7 @@ namespace Neo.IronLua
 					throw TypeParseException(offset, fullName, "array|generic");
 				else if (fullName[offset] == ',' || fullName[offset] == ']') // array
 				{
-				#region -- array --
+					#region -- array --
 					// count the number of dimension
 					var startAt = offset - 1;
 					var rank = 1;
@@ -1442,11 +1442,11 @@ namespace Neo.IronLua
 					}
 					else
 						throw TypeParseException(offset, fullName, "]");
-				#endregion
+					#endregion
 				}
 				else // generic definition
 				{
-				#region -- generic --
+					#region -- generic --
 					// collect generic arguments
 					var genericArguments = new List<LuaType>();
 					var sbTypeName = new StringBuilder("[");

--- a/NeoLua/LuaType.cs
+++ b/NeoLua/LuaType.cs
@@ -436,22 +436,53 @@ namespace Neo.IronLua
 
 			private DynamicMetaObject BindNewObject(LuaType luaType, CallInfo callInfo, DynamicMetaObject[] args, Type returnType)
 			{
+				bool IsLuaTableInit(ConstructorInfo c)
+				{
+					var a = c.GetParameters();
+					return a.Length == 0 || (a.Length == 1 && a[0].ParameterType == typeof(LuaTable));
+				} // func IsLuaTableInit
+
 				var type = luaType.Type;
 
 				// find the ctor
+				var initObject = false;
 				ConstructorInfo constructorInfo;
 				var isValueType = type.GetTypeInfo().IsValueType;
 				if (isValueType && args.Length == 0) // value-types with zero arguments always constructable
 					constructorInfo = null;
 				else
 				{
-					constructorInfo = LuaEmit.FindMember<ConstructorInfo, DynamicMetaObject>(
-						luaType.EnumerateMembers<ConstructorInfo>(
+					if (args.Length == 1 && args[0].LimitType == typeof(LuaTable))
+					{
+						constructorInfo = null;
+
+						foreach (var c in luaType.EnumerateMembers<ConstructorInfo>(
 							LuaMethodEnumerate.Typed,
-							declaredMembers => declaredMembers.OfType<ConstructorInfo>().Where(c => c.DeclaringType == type)
-						),
-						callInfo, args, mo => mo.LimitType, false
-					);
+							declaredMembers => declaredMembers.OfType<ConstructorInfo>().Where(c => c.DeclaringType == type && IsLuaTableInit(c))
+						))
+						{
+							if (c.GetParameters().Length == 1) // table init
+							{
+								constructorInfo = c;
+								break; // always use this
+							}
+							else // default ctor found
+							{
+								constructorInfo = c;
+								initObject = true;
+							}
+						}
+					}
+					else
+					{
+						constructorInfo = LuaEmit.FindMember(
+							luaType.EnumerateMembers<ConstructorInfo>(
+								LuaMethodEnumerate.Typed,
+								declaredMembers => declaredMembers.OfType<ConstructorInfo>().Where(c => c.DeclaringType == type)
+							),
+							callInfo, args, mo => mo.LimitType, false
+						);
+					}
 				}
 
 				var restrictions = BindingRestrictions.GetInstanceRestriction(Expression, Value).Merge(Lua.GetMethodSignatureRestriction(null, args));
@@ -459,7 +490,7 @@ namespace Neo.IronLua
 				// ctor not found for a class
 				if (constructorInfo == null && !isValueType)
 					return new DynamicMetaObject(Lua.ThrowExpression(String.Format(Properties.Resources.rsMemberNotResolved, luaType.FullName, "ctor"), returnType), restrictions);
-				else          // create the object
+				else // create the object
 				{
 					var expr = Lua.EnsureType(
 						LuaEmit.BindParameter(null,
@@ -470,6 +501,10 @@ namespace Neo.IronLua
 							mo => mo.Expression, mo => mo.LimitType, false),
 						returnType, true
 					);
+
+					if (initObject)
+						expr = Expression.Call(Lua.EnsureType(args[0].Expression, typeof(LuaTable)), Lua.TableSetObjectMemberMethodInfo, expr, Expression.Constant(true, typeof(bool)));
+
 					return new DynamicMetaObject(expr, restrictions);
 				}
 			} // func BindNewObject
@@ -860,15 +895,15 @@ namespace Neo.IronLua
 				if (!(c is T))
 					continue;
 
-				if (c is MethodBase && !IsCallableMethod((MethodBase)c, searchStatic))
+				if (c is MethodBase mb && !IsCallableMethod(mb, searchStatic))
 					continue;
-				else if (c is PropertyInfo && !IsCallableMethod(((PropertyInfo)c).GetMethod, searchStatic))
+				else if (c is PropertyInfo pi && !IsCallableMethod(pi.GetMethod, searchStatic))
 					continue;
-				else if (c is FieldInfo && !IsCallableField((FieldInfo)c, searchStatic))
+				else if (c is FieldInfo fi && !IsCallableField(fi, searchStatic))
 					continue;
-				else if (c is EventInfo && !IsCallableMethod(((EventInfo)c).AddMethod, searchStatic))
+				else if (c is EventInfo ei && !IsCallableMethod(ei.AddMethod, searchStatic))
 					continue;
-				else if (c is TypeInfo && !((TypeInfo)c).IsNestedPublic)
+				else if (c is TypeInfo ti && !ti.IsNestedPublic)
 					continue;
 
 				yield return (T)c;

--- a/NeoLua/LuaType.cs
+++ b/NeoLua/LuaType.cs
@@ -1114,7 +1114,7 @@ namespace Neo.IronLua
 				object System.Collections.IEnumerator.Current { get { return Current; } }
 			} // class AssemblyCacheEnumerator
 
-#endregion
+			#endregion
 
 			private readonly Dictionary<string, CacheItem> cache = new Dictionary<string, CacheItem>(StringComparer.OrdinalIgnoreCase);
 			private CacheItem first = null;
@@ -1275,7 +1275,7 @@ namespace Neo.IronLua
 			int ILuaTypeResolver.Version => assemblyCount;
 		} // class AssemblyCacheList
 
-#endregion
+		#endregion
 
 		private static readonly LuaType clr = new LuaType();                 // root type
 
@@ -1326,7 +1326,7 @@ namespace Neo.IronLua
 			LookupReferencedAssemblies = true;
 		} // /sctor
 
-#region -- Operator -----------------------------------------------------------
+		#region -- Operator -----------------------------------------------------------
 
 		/// <summary>implicit convert to type</summary>
 		/// <param name="type">lua-type that should convert.</param>
@@ -1334,9 +1334,9 @@ namespace Neo.IronLua
 		public static implicit operator Type(LuaType type)
 			=> type?.Type;
 
-#endregion
+		#endregion
 
-#region -- AddType ------------------------------------------------------------
+		#region -- AddType ------------------------------------------------------------
 
 		private static int AddType(LuaType type)
 		{
@@ -1368,9 +1368,9 @@ namespace Neo.IronLua
 			}
 		} // func GetTypeIndex
 
-#endregion
+		#endregion
 
-#region -- GetType ------------------------------------------------------------
+		#region -- GetType ------------------------------------------------------------
 
 		internal static LuaType GetType(int index)
 		{
@@ -1419,7 +1419,7 @@ namespace Neo.IronLua
 					throw TypeParseException(offset, fullName, "array|generic");
 				else if (fullName[offset] == ',' || fullName[offset] == ']') // array
 				{
-#region -- array --
+				#region -- array --
 					// count the number of dimension
 					var startAt = offset - 1;
 					var rank = 1;
@@ -1442,11 +1442,11 @@ namespace Neo.IronLua
 					}
 					else
 						throw TypeParseException(offset, fullName, "]");
-#endregion
+				#endregion
 				}
 				else // generic definition
 				{
-#region -- generic --
+				#region -- generic --
 					// collect generic arguments
 					var genericArguments = new List<LuaType>();
 					var sbTypeName = new StringBuilder("[");
@@ -1490,12 +1490,12 @@ namespace Neo.IronLua
 					else
 						return GetType(luaType, offset, fullName, ignoreCase, type);
 
-#endregion
+					#endregion
 				}
 			}
 			else // type or namespace
 			{
-#region -- type, namespace --
+				#region -- type, namespace --
 				// get the current part of the name
 				var nextOffset = fullName.IndexOfAny(new char[] { '.', '+', '[', ',' }, offset);
 				var currentPart = nextOffset == -1 ? fullName.Substring(offset) : fullName.Substring(offset, nextOffset - offset);
@@ -1529,7 +1529,7 @@ namespace Neo.IronLua
 				{
 					return GetType(GetType(current.AddType(currentPart, ignoreCase, null)), nextOffset + 1, fullName, ignoreCase, type);
 				}
-#endregion
+				#endregion
 			}
 		} // func GetType
 
@@ -1631,9 +1631,9 @@ namespace Neo.IronLua
 			}
 		} // func GetCachedType
 
-#endregion
+		#endregion
 
-#region -- RegisterTypeAlias --------------------------------------------------
+		#region -- RegisterTypeAlias --------------------------------------------------
 
 		/// <summary>Register a new type alias.</summary>
 		/// <param name="aliasName">Name of the type alias. It should be a identifier.</param>
@@ -1714,7 +1714,7 @@ namespace Neo.IronLua
 			}
 		} // proc RegisterMethodExtension
 
-#endregion
+		#endregion
 
 		/// <summary>Root for all clr-types.</summary>
 		public static LuaType Clr => clr;
@@ -1735,9 +1735,9 @@ namespace Neo.IronLua
 		public static bool UseUnsafeLookup { get; set; } = false;
 	} // class LuaType
 
-#endregion
+	#endregion
 
-#region -- interface ILuaMethod ---------------------------------------------------
+	#region -- interface ILuaMethod ---------------------------------------------------
 
 	/// <summary></summary>
 	public interface ILuaMethod
@@ -1752,14 +1752,14 @@ namespace Neo.IronLua
 		bool IsMemberCall { get; }
 	} // interface ILuaMethod
 
-#endregion
+	#endregion
 
-#region -- class LuaMethod --------------------------------------------------------
+	#region -- class LuaMethod --------------------------------------------------------
 
 	/// <summary>Represents overloaded members.</summary>
 	public sealed class LuaMethod : ILuaMethod, IDynamicMetaObjectProvider
 	{
-#region -- class LuaMethodMetaObject ------------------------------------------
+		#region -- class LuaMethodMetaObject ------------------------------------------
 
 		private class LuaMethodMetaObject : DynamicMetaObject
 		{
@@ -1797,13 +1797,13 @@ namespace Neo.IronLua
 			} // func BindConvert
 		} // class LuaMethodMetaObject
 
-#endregion
+		#endregion
 
 		private readonly object instance;
 		private readonly bool isMemberCall;
 		private readonly MethodInfo method;
 
-#region -- Ctor/Dtor -----------------------------------------------------------
+		#region -- Ctor/Dtor -----------------------------------------------------------
 
 		/// <summary></summary>
 		/// <param name="instance"></param>
@@ -1819,7 +1819,7 @@ namespace Neo.IronLua
 		DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
 			=> new LuaMethodMetaObject(parameter, this);
 
-#endregion
+		#endregion
 
 		/// <summary></summary>
 		/// <returns></returns>
@@ -1934,14 +1934,14 @@ namespace Neo.IronLua
 		} // func ConvertToType
 	} // class LuaMethod
 
-#endregion
+	#endregion
 
-#region -- class LuaOverloadedMethod ----------------------------------------------
+	#region -- class LuaOverloadedMethod ----------------------------------------------
 
 	/// <summary>Represents overloaded members.</summary>
 	public sealed class LuaOverloadedMethod : ILuaMethod, IDynamicMetaObjectProvider, IEnumerable<Delegate>
 	{
-#region -- class LuaOverloadedMethodMetaObject --------------------------------
+		#region -- class LuaOverloadedMethodMetaObject --------------------------------
 
 		private class LuaOverloadedMethodMetaObject : DynamicMetaObject
 		{
@@ -1950,7 +1950,7 @@ namespace Neo.IronLua
 			{
 			} // ctor
 
-#region -- BindGetIndex ---------------------------------------------------
+			#region -- BindGetIndex ---------------------------------------------------
 
 			private static Expression ConvertToType(DynamicMetaObject mo)
 			{
@@ -1991,9 +1991,9 @@ namespace Neo.IronLua
 				);
 			} // func BindGetIndex
 
-#endregion
+			#endregion
 
-#region -- BindInvoke -----------------------------------------------------
+			#region -- BindInvoke -----------------------------------------------------
 
 			public override DynamicMetaObject BindInvoke(InvokeBinder binder, DynamicMetaObject[] args)
 			{
@@ -2025,9 +2025,9 @@ namespace Neo.IronLua
 				}
 			} // proc BindInvoke
 
-#endregion
+			#endregion
 
-#region -- BindConvert ----------------------------------------------------
+			#region -- BindConvert ----------------------------------------------------
 
 			public override DynamicMetaObject BindConvert(ConvertBinder binder)
 			{
@@ -2051,16 +2051,16 @@ namespace Neo.IronLua
 					return base.BindConvert(binder);
 			} // func BindConvert
 
-#endregion
+			#endregion
 		} // class LuaOverloadedMethodMetaObject
 
-#endregion
+		#endregion
 
 		private readonly object instance;
 		private readonly bool isMemberCall;
 		private readonly MethodInfo[] methods;
 
-#region -- Ctor/Dtor ----------------------------------------------------------
+		#region -- Ctor/Dtor ----------------------------------------------------------
 
 		/// <summary></summary>
 		/// <param name="instance"></param>
@@ -2082,9 +2082,9 @@ namespace Neo.IronLua
 		DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
 			=> new LuaOverloadedMethodMetaObject(parameter, this);
 
-#endregion
+		#endregion
 
-#region -- GetDelegate, GetMethod ---------------------------------------------
+		#region -- GetDelegate, GetMethod ---------------------------------------------
 
 		private MethodInfo FindMethod(bool exactMatchesOnly, CallInfo callInfo, params Type[] types)
 		{
@@ -2171,7 +2171,7 @@ namespace Neo.IronLua
 		public LuaMethod GetMethod(int index)
 			=> index >= 0 && index < methods.Length ? new LuaMethod(instance, methods[index], false) : null;
 
-#endregion
+		#endregion
 
 		/// <summary></summary>
 		/// <returns></returns>
@@ -2207,14 +2207,14 @@ namespace Neo.IronLua
 		public int Count => methods.Length;
 	} // class LuaOverloadedMethod
 
-#endregion
+	#endregion
 
-#region -- class LuaEvent ---------------------------------------------------------
+	#region -- class LuaEvent ---------------------------------------------------------
 
 	/// <summary></summary>
 	public sealed class LuaEvent : ILuaMethod, IDynamicMetaObjectProvider
 	{
-#region -- class LuaEventMetaObject -------------------------------------------
+		#region -- class LuaEventMetaObject -------------------------------------------
 
 		private class LuaEventMetaObject : DynamicMetaObject
 		{
@@ -2227,7 +2227,7 @@ namespace Neo.IronLua
 			{
 			} // ctor
 
-#region -- BindAddMethod, BindRemoveMethod, BindGetMember -----------------
+			#region -- BindAddMethod, BindRemoveMethod, BindGetMember -----------------
 
 			private DynamicMetaObject BindAddMethod(DynamicMetaObjectBinder binder, DynamicMetaObject[] args)
 			{
@@ -2257,9 +2257,9 @@ namespace Neo.IronLua
 				);
 			} // func BindGetMember
 
-#endregion
+			#endregion
 
-#region -- Binder ---------------------------------------------------------
+			#region -- Binder ---------------------------------------------------------
 
 			public override DynamicMetaObject BindBinaryOperation(BinaryOperationBinder binder, DynamicMetaObject arg)
 			{
@@ -2303,15 +2303,15 @@ namespace Neo.IronLua
 					return base.BindInvokeMember(binder, args);
 			} // func BindInvokeMember
 
-#endregion
+			#endregion
 		} // class LuaEventMetaObject
 
-#endregion
+		#endregion
 
 		private readonly object instance;
 		private readonly EventInfo eventInfo;
 
-#region -- Ctor/Dtor ----------------------------------------------------------
+		#region -- Ctor/Dtor ----------------------------------------------------------
 
 		internal LuaEvent(object instance, EventInfo eventInfo)
 		{
@@ -2322,7 +2322,7 @@ namespace Neo.IronLua
 		DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
 			=> new LuaEventMetaObject(parameter, this);
 
-#endregion
+		#endregion
 
 		/// <summary></summary>
 		/// <returns></returns>
@@ -2343,5 +2343,5 @@ namespace Neo.IronLua
 		internal MethodInfo RaiseMethodInfo => eventInfo.RaiseMethod;
 	} // class LuaEvent
 
-#endregion
+	#endregion
 }

--- a/NeoLua/LuaType.cs
+++ b/NeoLua/LuaType.cs
@@ -1069,9 +1069,24 @@ namespace Neo.IronLua
 							{
 								try
 								{
+#if NETCOREAPP1_0_OR_GREATER
+									if (UseUnsafeLookup)
+									{
+										currentAssembly =
+											current.reflected =
+											Assembly.UnsafeLoadFrom(current.Name.FullName);
+									}
+									else
+									{
+										currentAssembly =
+											current.reflected =
+											Assembly.Load(current.Name.FullName);
+									}
+#else
 									currentAssembly =
 										current.reflected =
 										Assembly.ReflectionOnlyLoad(current.Name.FullName);
+#endif
 								}
 								catch
 								{
@@ -1099,7 +1114,7 @@ namespace Neo.IronLua
 				object System.Collections.IEnumerator.Current { get { return Current; } }
 			} // class AssemblyCacheEnumerator
 
-			#endregion
+#endregion
 
 			private readonly Dictionary<string, CacheItem> cache = new Dictionary<string, CacheItem>(StringComparer.OrdinalIgnoreCase);
 			private CacheItem first = null;
@@ -1260,7 +1275,7 @@ namespace Neo.IronLua
 			int ILuaTypeResolver.Version => assemblyCount;
 		} // class AssemblyCacheList
 
-		#endregion
+#endregion
 
 		private static readonly LuaType clr = new LuaType();                 // root type
 
@@ -1311,7 +1326,7 @@ namespace Neo.IronLua
 			LookupReferencedAssemblies = true;
 		} // /sctor
 
-		#region -- Operator -----------------------------------------------------------
+#region -- Operator -----------------------------------------------------------
 
 		/// <summary>implicit convert to type</summary>
 		/// <param name="type">lua-type that should convert.</param>
@@ -1319,9 +1334,9 @@ namespace Neo.IronLua
 		public static implicit operator Type(LuaType type)
 			=> type?.Type;
 
-		#endregion
+#endregion
 
-		#region -- AddType ------------------------------------------------------------
+#region -- AddType ------------------------------------------------------------
 
 		private static int AddType(LuaType type)
 		{
@@ -1353,9 +1368,9 @@ namespace Neo.IronLua
 			}
 		} // func GetTypeIndex
 
-		#endregion
+#endregion
 
-		#region -- GetType ------------------------------------------------------------
+#region -- GetType ------------------------------------------------------------
 
 		internal static LuaType GetType(int index)
 		{
@@ -1404,7 +1419,7 @@ namespace Neo.IronLua
 					throw TypeParseException(offset, fullName, "array|generic");
 				else if (fullName[offset] == ',' || fullName[offset] == ']') // array
 				{
-					#region -- array --
+#region -- array --
 					// count the number of dimension
 					var startAt = offset - 1;
 					var rank = 1;
@@ -1427,11 +1442,11 @@ namespace Neo.IronLua
 					}
 					else
 						throw TypeParseException(offset, fullName, "]");
-					#endregion
+#endregion
 				}
 				else // generic definition
 				{
-					#region -- generic --
+#region -- generic --
 					// collect generic arguments
 					var genericArguments = new List<LuaType>();
 					var sbTypeName = new StringBuilder("[");
@@ -1475,12 +1490,12 @@ namespace Neo.IronLua
 					else
 						return GetType(luaType, offset, fullName, ignoreCase, type);
 
-					#endregion
+#endregion
 				}
 			}
 			else // type or namespace
 			{
-				#region -- type, namespace --
+#region -- type, namespace --
 				// get the current part of the name
 				var nextOffset = fullName.IndexOfAny(new char[] { '.', '+', '[', ',' }, offset);
 				var currentPart = nextOffset == -1 ? fullName.Substring(offset) : fullName.Substring(offset, nextOffset - offset);
@@ -1514,7 +1529,7 @@ namespace Neo.IronLua
 				{
 					return GetType(GetType(current.AddType(currentPart, ignoreCase, null)), nextOffset + 1, fullName, ignoreCase, type);
 				}
-				#endregion
+#endregion
 			}
 		} // func GetType
 
@@ -1616,9 +1631,9 @@ namespace Neo.IronLua
 			}
 		} // func GetCachedType
 
-		#endregion
+#endregion
 
-		#region -- RegisterTypeAlias --------------------------------------------------
+#region -- RegisterTypeAlias --------------------------------------------------
 
 		/// <summary>Register a new type alias.</summary>
 		/// <param name="aliasName">Name of the type alias. It should be a identifier.</param>
@@ -1699,7 +1714,7 @@ namespace Neo.IronLua
 			}
 		} // proc RegisterMethodExtension
 
-		#endregion
+#endregion
 
 		/// <summary>Root for all clr-types.</summary>
 		public static LuaType Clr => clr;
@@ -1710,11 +1725,19 @@ namespace Neo.IronLua
 		public static ILuaTypeResolver DefaultResolver { get; } = new AssemblyCacheList();
 		/// <summary>Should the type resolve also scan references assemblies (default is true).</summary>
 		public static bool LookupReferencedAssemblies { get; set; }
+		/// <summary>
+		/// Should assemblies be loaded in an unsafe manner. <br/>
+		/// False by default, set it to true to speed up loading at the cost of safety. <br/>
+		/// Only has an effect if <see cref="LookupReferencedAssemblies"/> is true. <br/>
+		/// When this property is true assemblies are loaded through <see cref="Assembly.UnsafeLoadFrom"/> 
+		/// instead of <see cref="Assembly.Load(string)"/>
+		/// </summary>
+		public static bool UseUnsafeLookup { get; set; } = false;
 	} // class LuaType
 
-	#endregion
+#endregion
 
-	#region -- interface ILuaMethod ---------------------------------------------------
+#region -- interface ILuaMethod ---------------------------------------------------
 
 	/// <summary></summary>
 	public interface ILuaMethod
@@ -1729,14 +1752,14 @@ namespace Neo.IronLua
 		bool IsMemberCall { get; }
 	} // interface ILuaMethod
 
-	#endregion
+#endregion
 
-	#region -- class LuaMethod --------------------------------------------------------
+#region -- class LuaMethod --------------------------------------------------------
 
 	/// <summary>Represents overloaded members.</summary>
 	public sealed class LuaMethod : ILuaMethod, IDynamicMetaObjectProvider
 	{
-		#region -- class LuaMethodMetaObject ------------------------------------------
+#region -- class LuaMethodMetaObject ------------------------------------------
 
 		private class LuaMethodMetaObject : DynamicMetaObject
 		{
@@ -1774,13 +1797,13 @@ namespace Neo.IronLua
 			} // func BindConvert
 		} // class LuaMethodMetaObject
 
-		#endregion
+#endregion
 
 		private readonly object instance;
 		private readonly bool isMemberCall;
 		private readonly MethodInfo method;
 
-		#region -- Ctor/Dtor -----------------------------------------------------------
+#region -- Ctor/Dtor -----------------------------------------------------------
 
 		/// <summary></summary>
 		/// <param name="instance"></param>
@@ -1796,7 +1819,7 @@ namespace Neo.IronLua
 		DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
 			=> new LuaMethodMetaObject(parameter, this);
 
-		#endregion
+#endregion
 
 		/// <summary></summary>
 		/// <returns></returns>
@@ -1911,14 +1934,14 @@ namespace Neo.IronLua
 		} // func ConvertToType
 	} // class LuaMethod
 
-	#endregion
+#endregion
 
-	#region -- class LuaOverloadedMethod ----------------------------------------------
+#region -- class LuaOverloadedMethod ----------------------------------------------
 
 	/// <summary>Represents overloaded members.</summary>
 	public sealed class LuaOverloadedMethod : ILuaMethod, IDynamicMetaObjectProvider, IEnumerable<Delegate>
 	{
-		#region -- class LuaOverloadedMethodMetaObject --------------------------------
+#region -- class LuaOverloadedMethodMetaObject --------------------------------
 
 		private class LuaOverloadedMethodMetaObject : DynamicMetaObject
 		{
@@ -1927,7 +1950,7 @@ namespace Neo.IronLua
 			{
 			} // ctor
 
-			#region -- BindGetIndex ---------------------------------------------------
+#region -- BindGetIndex ---------------------------------------------------
 
 			private static Expression ConvertToType(DynamicMetaObject mo)
 			{
@@ -1968,9 +1991,9 @@ namespace Neo.IronLua
 				);
 			} // func BindGetIndex
 
-			#endregion
+#endregion
 
-			#region -- BindInvoke -----------------------------------------------------
+#region -- BindInvoke -----------------------------------------------------
 
 			public override DynamicMetaObject BindInvoke(InvokeBinder binder, DynamicMetaObject[] args)
 			{
@@ -2002,9 +2025,9 @@ namespace Neo.IronLua
 				}
 			} // proc BindInvoke
 
-			#endregion
+#endregion
 
-			#region -- BindConvert ----------------------------------------------------
+#region -- BindConvert ----------------------------------------------------
 
 			public override DynamicMetaObject BindConvert(ConvertBinder binder)
 			{
@@ -2028,16 +2051,16 @@ namespace Neo.IronLua
 					return base.BindConvert(binder);
 			} // func BindConvert
 
-			#endregion
+#endregion
 		} // class LuaOverloadedMethodMetaObject
 
-		#endregion
+#endregion
 
 		private readonly object instance;
 		private readonly bool isMemberCall;
 		private readonly MethodInfo[] methods;
 
-		#region -- Ctor/Dtor ----------------------------------------------------------
+#region -- Ctor/Dtor ----------------------------------------------------------
 
 		/// <summary></summary>
 		/// <param name="instance"></param>
@@ -2059,9 +2082,9 @@ namespace Neo.IronLua
 		DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
 			=> new LuaOverloadedMethodMetaObject(parameter, this);
 
-		#endregion
+#endregion
 
-		#region -- GetDelegate, GetMethod ---------------------------------------------
+#region -- GetDelegate, GetMethod ---------------------------------------------
 
 		private MethodInfo FindMethod(bool exactMatchesOnly, CallInfo callInfo, params Type[] types)
 		{
@@ -2148,7 +2171,7 @@ namespace Neo.IronLua
 		public LuaMethod GetMethod(int index)
 			=> index >= 0 && index < methods.Length ? new LuaMethod(instance, methods[index], false) : null;
 
-		#endregion
+#endregion
 
 		/// <summary></summary>
 		/// <returns></returns>
@@ -2184,14 +2207,14 @@ namespace Neo.IronLua
 		public int Count => methods.Length;
 	} // class LuaOverloadedMethod
 
-	#endregion
+#endregion
 
-	#region -- class LuaEvent ---------------------------------------------------------
+#region -- class LuaEvent ---------------------------------------------------------
 
 	/// <summary></summary>
 	public sealed class LuaEvent : ILuaMethod, IDynamicMetaObjectProvider
 	{
-		#region -- class LuaEventMetaObject -------------------------------------------
+#region -- class LuaEventMetaObject -------------------------------------------
 
 		private class LuaEventMetaObject : DynamicMetaObject
 		{
@@ -2204,7 +2227,7 @@ namespace Neo.IronLua
 			{
 			} // ctor
 
-			#region -- BindAddMethod, BindRemoveMethod, BindGetMember -----------------
+#region -- BindAddMethod, BindRemoveMethod, BindGetMember -----------------
 
 			private DynamicMetaObject BindAddMethod(DynamicMetaObjectBinder binder, DynamicMetaObject[] args)
 			{
@@ -2234,9 +2257,9 @@ namespace Neo.IronLua
 				);
 			} // func BindGetMember
 
-			#endregion
+#endregion
 
-			#region -- Binder ---------------------------------------------------------
+#region -- Binder ---------------------------------------------------------
 
 			public override DynamicMetaObject BindBinaryOperation(BinaryOperationBinder binder, DynamicMetaObject arg)
 			{
@@ -2280,15 +2303,15 @@ namespace Neo.IronLua
 					return base.BindInvokeMember(binder, args);
 			} // func BindInvokeMember
 
-			#endregion
+#endregion
 		} // class LuaEventMetaObject
 
-		#endregion
+#endregion
 
 		private readonly object instance;
 		private readonly EventInfo eventInfo;
 
-		#region -- Ctor/Dtor ----------------------------------------------------------
+#region -- Ctor/Dtor ----------------------------------------------------------
 
 		internal LuaEvent(object instance, EventInfo eventInfo)
 		{
@@ -2299,7 +2322,7 @@ namespace Neo.IronLua
 		DynamicMetaObject IDynamicMetaObjectProvider.GetMetaObject(Expression parameter)
 			=> new LuaEventMetaObject(parameter, this);
 
-		#endregion
+#endregion
 
 		/// <summary></summary>
 		/// <returns></returns>
@@ -2320,5 +2343,5 @@ namespace Neo.IronLua
 		internal MethodInfo RaiseMethodInfo => eventInfo.RaiseMethod;
 	} // class LuaEvent
 
-	#endregion
+#endregion
 }

--- a/NeoLua/NeoLua.csproj
+++ b/NeoLua/NeoLua.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 		<AssemblyName>Neo.Lua</AssemblyName>
 		<RootNamespace>Neo.IronLua</RootNamespace>
-		<TargetFrameworks>net45;net47;netstandard2.0;netcoreapp2.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>net45;net47;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Description>A Lua implementation for the Dynamic Language Runtime (DLR).</Description>
 		<PackageId>NeoLua</PackageId>

--- a/NeoLua/Parser.cs
+++ b/NeoLua/Parser.cs
@@ -1991,8 +1991,16 @@ namespace Neo.IronLua
 					code.Next();
 					loopStep = ParseExpression(scope, code, InvokeResult.Object, scope.EmitExpressionDebug);
 				}
+				else if (loopStart.Type == typeof(int))
+					loopStep = Expression.Constant(1);
+				else if (loopStart.Type == typeof(long))
+					loopStep = Expression.Constant(1L);
+				else if (loopStart.Type == typeof(float))
+					loopStep = Expression.Constant(1.0f);
+				else if (loopStart.Type == typeof(double))
+					loopStep = Expression.Constant(1.0);
 				else
-					loopStep = Expression.Constant(1, loopStart.Type);
+					loopStep = Expression.Constant(Lua.RtConvertValue(1, loopStart.Type));
 
 				var loopScope = new LoopScope(scope);
 				var loopVarParameter = loopScope.RegisterVariable(typeLoopVar == typeof(object) ? LuaEmit.LiftType(LuaEmit.LiftType(loopStart.Type, loopEnd.Type), loopStep.Type) : typeLoopVar, tLoopVar.Value);

--- a/NeoLua/Properties/Resources.Designer.cs
+++ b/NeoLua/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Neo.IronLua.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -588,6 +588,15 @@ namespace Neo.IronLua.Properties {
         internal static string rsTableRecursionLevelError {
             get {
                 return ResourceManager.GetString("rsTableRecursionLevelError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not set member {1}.{0}..
+        /// </summary>
+        internal static string rsTableSetValueFailed {
+            get {
+                return ResourceManager.GetString("rsTableSetValueFailed", resourceCulture);
             }
         }
         

--- a/NeoLua/Properties/Resources.de.resx
+++ b/NeoLua/Properties/Resources.de.resx
@@ -294,6 +294,9 @@
   <data name="rsTableRecursionLevelError" xml:space="preserve">
     <value>Tabelle ist zu tief geschachtelt.</value>
   </data>
+  <data name="rsTableSetValueFailed" xml:space="preserve">
+    <value>Member kann nicht gesetzt werden {1}.{0}.</value>
+  </data>
   <data name="rsTypeAliasInvalidName" xml:space="preserve">
     <value>Name für Type ist ungültig '{0}'.</value>
   </data>

--- a/NeoLua/Properties/Resources.resx
+++ b/NeoLua/Properties/Resources.resx
@@ -294,6 +294,9 @@
   <data name="rsTableRecursionLevelError" xml:space="preserve">
     <value>Recursion level is to deep.</value>
   </data>
+  <data name="rsTableSetValueFailed" xml:space="preserve">
+    <value>Could not set member {1}.{0}.</value>
+  </data>
   <data name="rsTypeAliasInvalidName" xml:space="preserve">
     <value>Name for type alias is invalid '{0}'.</value>
   </data>


### PR DESCRIPTION
Modification to the routine in AssemblyCacheEnumerator::MoveNext to use Assembly.Load instead of Assembly.ReflectionOnlyLoad under .Net Core and .Net 5+ as Assembly.ReflectionOnlyLoad is not supported on those runtimes and is guaranteed to throw PlatformNotSupportedExceptions. 

Exposing additional static property to permit the user to use UnsafeLoadFrom in Assembly loading should the user want to load assemblies faster. This option is off by default for safety reasons and to preserve earlier behaviour. 

Under initial testing, UnsafeLoadFrom is ~10x faster and dropped load times in a built app from 5 seconds to 0.5 seconds. 