### PR TITLE
Added overloaded atan

### DIFF
--- a/NeoLua/LuaLibraries.cs
+++ b/NeoLua/LuaLibraries.cs
@@ -731,6 +731,13 @@ namespace Neo.IronLua
 		public static double atan(double x)
 			=> Math.Atan(x);
 
+		/// <summary>Implementation of http://www.lua.org/manual/5.3/manual.html#pdf-math.atan </summary>
+		/// <param name="y"></param>
+		/// <param name="x"></param>
+		/// <returns></returns>
+		public static double atan(double y, double x)
+			=> Math.Atan2(y, x);
+
 		/// <summary>Implementation of http://www.lua.org/manual/5.2/manual.html#pdf-math.atan2 </summary>
 		/// <param name="y"></param>
 		/// <param name="x"></param>


### PR DESCRIPTION
Lua 5.3 deprecated `math.atan2(y, x)`.  Most IDEs have begun showing a warning about this.

Lua 5.3 also added a new overload `math.atan(y [, x])`, which now accepts two parameters making it the intended replacement for `math.atan2(y, x)`:

**Deprecations in 5.3:** https://www.lua.org/manual/5.3/manual.html#8.2
**math.atan(y [, x]) in 5.3:** http://www.lua.org/manual/5.3/manual.html#pdf-math.atan

I think normally it would make sense to provide a default value (shown below) to keep it a single function instead of requiring the overload, but because the existing parameter is named `x`, it would break any scripts which manually specify the parameter name.

```cs
public static double atan(double y, double x = 1)
			=> Math.Atan2(y, x);
```