### PR TITLE
Ensure lua can replace '?' in packa path with module name when requiring modules.

### DIFF
--- a/NeoLua.Test/LuaLibs.cs
+++ b/NeoLua.Test/LuaLibs.cs
@@ -161,5 +161,50 @@ namespace LuaDLR.Test
 				23, 42
 			);
 		}
+
+		[TestMethod]
+		public void TestRequire01()
+		{
+			// Lua should find a module by replacing '?' with the module name in the package path.
+			Directory.CreateDirectory("lua_module");
+			File.WriteAllText(Path.Combine("lua_module", "ReqModule.lua"), "function foo() return 'bar' end");
+
+			TestCode(Lines(
+				"package.path = package.path..';./lua_module/?.lua'",
+				"require('ReqModule');",
+				"return foo();"),
+				"bar"
+			);
+		}
+
+		[TestMethod]
+		public void TestRequire02()
+		{
+			// Lua should find a module by searching for the module in package path directories
+			Directory.CreateDirectory("lua_module");
+			File.WriteAllText(Path.Combine("lua_module", "ReqModule.lua"), "function foo() return 'bar' end");
+
+			TestCode(Lines(
+					"package.path = package.path..';./lua_module'",
+					"require('ReqModule');",
+					"return foo();"),
+				"bar"
+			);
+		}
+
+		[TestMethod]
+		public void TestRequire03()
+		{
+			// Lua should find a module by replacing '?' with the module name in the environment LUA_PATH.
+			Directory.CreateDirectory("lua_module");
+			File.WriteAllText(Path.Combine("lua_module", "ReqModule.lua"), "function foo() return 'bar' end");
+			Environment.SetEnvironmentVariable("LUA_PATH", "./lua_module/?.lua");
+			TestCode(Lines(
+			
+					"require('ReqModule');",
+					"return foo();"),
+				"bar"
+			);
+		}
 	}
 }

--- a/NeoLua/NeoLua.csproj
+++ b/NeoLua/NeoLua.csproj
@@ -20,6 +20,7 @@ This library contains the desktop parts of the lua implementation.</PackageRelea
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>NeoLua.snk</AssemblyOriginatorKeyFile>
     <Nullable>disable</Nullable>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 	<Import Project="..\NeoLua.NuGet\common.nupkg.targets" />
 	<ItemGroup>


### PR DESCRIPTION
From the lua manual

> For instance, if the path is the string
>
>    `"./?.lua;./?.lc;/usr/local/?/init.lua"`
>the search for the name foo.a will try to open the files `./foo/a.lua, ./foo/a.lc, and /usr/local/foo/a/init.lua,` in that order.

The package path is also initialized from the environment variable LUA_PATH,


> ### package.path
>The path used by [require](https://www.lua.org/manual/5.3/manual.html#pdf-require) to search for a Lua loader.
>At start-up, Lua initializes this variable with the value of the environment variable LUA_PATH_5_3 or the environment variable LUA_PATH
```