### PR TITLE
Fixes to overload resolution and exceptions

### DIFF
--- a/NeoLua.Dbg/NeoLua.Dbg.csproj
+++ b/NeoLua.Dbg/NeoLua.Dbg.csproj
@@ -4,7 +4,7 @@
 		<AssemblyName>Neo.Lua.Dbg</AssemblyName>
 		<RootNamespace>Neo.IronLua</RootNamespace>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<TargetFrameworks>net452;netcoreapp2.1</TargetFrameworks>
+		<TargetFrameworks>net452;net60</TargetFrameworks>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>NeoLua.snk</AssemblyOriginatorKeyFile>
 		<PackageId>NeoLuaDebug</PackageId>

--- a/NeoLua.NuGet/package.targets
+++ b/NeoLua.NuGet/package.targets
@@ -6,7 +6,7 @@
 	
 	<Import Project="$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets" Condition="Exists('$(MSBuildCommunityTasksPath)\MSBuild.Community.Tasks.Targets')" />
 	<Import Project="common.targets" />
-	<Import Project="package.apikey.targets" />
+	<Import Project="package.apikey.targets" Condition="Exists('package.apikey.targets')" />
 
 	<ItemGroup>
 		<ZipFileCmd Include="$(MSBuildProjectDirectory)\..\NeoCmd\bin\Release\net47\NeoCmd.exe" />

--- a/NeoLua.Test/Exceptions.cs
+++ b/NeoLua.Test/Exceptions.cs
@@ -24,12 +24,12 @@ namespace LuaDLR.Test
 				try
 				{
 					l.PrintExpressionTree = PrintExpressionTree ? Console.Out : null;
-					g.DoChunk(l.CompileChunk("\nNull(a, a);", "test.lua", Lua.StackTraceCompileOptions, new KeyValuePair<string, Type>("a", typeof(int))), 1);
+					g.DoChunk(l.CompileChunk("\nNull(a, a);\n", "test.lua", Lua.StackTraceCompileOptions, new KeyValuePair<string, Type>("a", typeof(int))), 1);
 				}
 				catch (Exception e)
 				{
 					var d = LuaExceptionData.GetData(e);
-					Assert.IsTrue(d[2].LineNumber == 2);
+					Assert.AreEqual(2,  d[2].LineNumber);
 				}
 			}
 		} // proc Exception01
@@ -50,7 +50,7 @@ namespace LuaDLR.Test
 					var d = LuaExceptionData.GetData(e);
 					Debug.Print("Error: {0}", e.Message);
 					Debug.Print("Error at:\n{0}", d.StackTrace);
-					Assert.IsTrue(d[2].LineNumber == 1); //  && d[2].ColumnNumber == 18 in release this is one
+					Assert.AreEqual(1, d[2].LineNumber); //  && d[2].ColumnNumber == 18 in release this is one
 				}
 			}
 		} // proc Exception01

--- a/NeoLua.Test/Expressions.cs
+++ b/NeoLua.Test/Expressions.cs
@@ -738,25 +738,87 @@ namespace LuaDLR.Test
 			TestExpr("~'2.1'", (long)~2);
 		}
 
-		[TestMethod]
-		public void TestArithmetic18()
+		[DataTestMethod]
+		[DataRow(2, -2)]
+		[DataRow(2.1, -2.1)]
+		[DataRow(ShortEnum.Zwei, (ShortEnum)(-2))]
+		public void TestArithmetic18(object input, object expected)
 		{
 			using (Lua l = new Lua())
 			{
 				l.PrintExpressionTree = Console.Out;
 
 				dynamic g = l.CreateEnvironment();
-				TestResult(g.dochunk("return -a", "dummy", "a", 2), -2);
-				TestResult(g.dochunk("return -a", "dummy", "a", 2.1), -2.1);
-				TestResult(g.dochunk("return -a", "dummy", "a", new TestOperator(2)), new TestOperator(-2));
-				TestResult(g.dochunk("return -a", "dummy", "a", new TestOperator2(2)), -2);
-				TestResult(g.dochunk("return -a", "dummy", "a", ShortEnum.Zwei), (ShortEnum)(-2));
+				TestResult(g.dochunk("return -a", "dummy", "a", input), expected);
+			}
+		}
 
-				TestResult(g.dochunk("return ~a", "dummy", "a", 2), ~2);
-				TestResult(g.dochunk("return ~a", "dummy", "a", 2.1), (long)~2);
+		[DataTestMethod]
+		[DataRow(2, ~2)]
+		[DataRow(2.1, (long)~2)]
+		[DataRow(ShortEnum.Zwei, (ShortEnum)(~2))]
+		public void TestArithmetic18_1(object input, object expected)
+		{
+			using (Lua l = new Lua())
+			{
+				l.PrintExpressionTree = Console.Out;
+
+				dynamic g = l.CreateEnvironment();
+				TestResult(g.dochunk("return ~a", "dummy", "a", input), expected);
+			}
+		}
+
+
+		[TestMethod]
+		public void TestArithmetic18_2()
+		{
+			using (Lua l = new Lua())
+			{
+				l.PrintExpressionTree = Console.Out;
+
+				dynamic g = l.CreateEnvironment();
+				
+				TestResult(g.dochunk("return -a", "dummy", "a", new TestOperator(2)), new TestOperator(-2));
+				
+			}
+		}
+
+		[TestMethod]
+		public void TestArithmetic18_3()
+		{
+			using (Lua l = new Lua())
+			{
+				l.PrintExpressionTree = Console.Out;
+
+				dynamic g = l.CreateEnvironment();
+
+				TestResult(g.dochunk("return -a", "dummy", "a", new TestOperator2(2)), -2.0);
+
+			}
+		}
+
+		[TestMethod]
+		public void TestArithmetic18_4()
+		{
+			using (Lua l = new Lua())
+			{
+				l.PrintExpressionTree = Console.Out;
+
+				dynamic g = l.CreateEnvironment();
+
 				TestResult(g.dochunk("return ~a", "dummy", "a", new TestOperator(2)), new TestOperator(~2));
-				TestResult(g.dochunk("return ~a", "dummy", "a", new TestOperator2(2)), ~2);
-				TestResult(g.dochunk("return ~a", "dummy", "a", ShortEnum.Zwei), (ShortEnum)~2);
+			}
+		}
+		[TestMethod]
+		public void TestArithmetic18_5()
+		{
+			using (Lua l = new Lua())
+			{
+				l.PrintExpressionTree = Console.Out;
+
+				dynamic g = l.CreateEnvironment();
+
+				TestResult(g.dochunk("return ~a", "dummy", "a", new TestOperator2(2)), (long)~2);
 			}
 		}
 
@@ -1088,7 +1150,7 @@ namespace LuaDLR.Test
 			TestCode(String.Join(Environment.NewLine,
 			  "local a : string = '2';",
 			  "return a == 2;"
-			  ), true);
+			  ),  true);
 		}
 
 		[TestMethod]

--- a/NeoLua.Test/LuaEmitTests.cs
+++ b/NeoLua.Test/LuaEmitTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Neo.IronLua;
+
+namespace LuaDLR.Test
+{
+	[TestClass]
+	public class LuaEmitTests
+	{
+		private LuaType LuaTypeString = LuaType.GetType(typeof(string));
+
+		[TestMethod]
+		public void FindMember_StringJoin_WithLuaResultMatchesObjectArrayOverload()
+		{
+			var arguments = GetDynamicMetaObjectArguments(" ", new LuaResult("Hello", "World", "!!"));
+			TestMethodInfoForArguments(typeof(string), nameof(string.Join), arguments, new[] { typeof(string), typeof(object[]) });
+		}
+
+		[TestMethod]
+		public void FindMember_StringStringFormat_WithStringObj()
+		{
+			var arguments = GetDynamicMetaObjectArguments("Hello {0}", "World");
+			TestMethodInfoForArguments(typeof(string), nameof(string.Format), arguments, new[] { typeof(string), typeof(object) });
+		}
+
+		[TestMethod]
+		public void FindMember_StringStringFormat_WithStringObjArray()
+		{
+			var arguments = GetDynamicMetaObjectArguments("Hello {0}{1}", new object[] { "World", "!!" });
+			TestMethodInfoForArguments(typeof(string), nameof(string.Format), arguments, new[] { typeof(string), typeof(object[]) });
+		}
+
+		[TestMethod]
+		public void FindMember_StringConcat_WithStringsAndLuaResultMatchesObjectArrayOverload()
+		{
+			var arguments = GetDynamicMetaObjectArguments("Test", ":", new LuaResult("Hello", "World", "!!"));
+			TestMethodInfoForArguments(typeof(string), nameof(string.Concat), arguments, new[] { typeof(object[]) });
+		}
+
+		[TestMethod]
+		public void FindMember_LuaResultGSub()
+		{
+			var arguments = GetDynamicMetaObjectArguments("abc", "a", "b");
+			TestMethodInfoForArguments(typeof(LuaLibraryString), nameof(LuaLibraryString.gsub), arguments, new[] { typeof(string) , typeof(string) , typeof(object), typeof(int) });
+		}
+
+
+		[TestMethod]
+		public void FindMember_ParamArrayWithNoArg()
+		{
+			var arguments = GetDynamicMetaObjectArguments();
+			TestMethodInfoForArguments(typeof(LuaFile), nameof(LuaFile.write), arguments, new[] { typeof(object[]) });
+		}
+
+		[TestMethod]
+		public void FindMember_ParamArrayWithSingleArg()
+		{
+			var arguments = GetDynamicMetaObjectArguments("Hello World");
+			TestMethodInfoForArguments(typeof(LuaFile), nameof(LuaFile.write), arguments, new[] { typeof(object[]) });
+		}
+
+		[TestMethod]
+		public void FindMember_ParamArrayWithMultipleArgs()
+		{
+			var arguments = GetDynamicMetaObjectArguments("Hello World", "Some more", "and another");
+			TestMethodInfoForArguments(typeof(LuaFile), nameof(LuaFile.write), arguments, new[] { typeof(object[]) });
+		}
+
+		void TestMethodInfoForArguments(Type type, string memberName, DynamicMetaObject[] arguments, Type[] argumentTypesForExpectedOverload)
+		{
+			var methodAlternatives = type.GetMember(memberName).Cast<MethodInfo>().ToArray();
+			var callInfo = new CallInfo(arguments.Length);
+			var methodInfo = LuaEmit.FindMember(methodAlternatives, callInfo, arguments, GetArgumentType, false);
+			Assert.IsNotNull(methodInfo, $"Found no valid overload for {type.Name}:{memberName}");
+			var expected = type.GetMethod(memberName, argumentTypesForExpectedOverload);
+			Assert.AreEqual(expected, methodInfo);
+		}
+
+		static Type GetArgumentType(DynamicMetaObject obj) => obj.LimitType;
+
+		DynamicMetaObject[] GetDynamicMetaObjectArguments(params object[] arguments)
+		{
+			DynamicMetaObject[] res = new DynamicMetaObject[arguments.Length];
+			for (int i = 0; i < arguments.Length; i++)
+			{
+				object argument = arguments[i];
+				var name = $"$arg{i + 1}";
+				res[i] = CreateMetaObjectParameter(name, argument);
+			}
+
+			return res;
+		}
+		
+		DynamicMetaObject CreateMetaObjectParameter(string name, object value)
+		{
+			var type = value is string ? LuaTypeString : value.GetType();
+			return DynamicMetaObject.Create(value, Expression.Parameter(type, name));
+		}
+	}
+}

--- a/NeoLua.Test/LuaType.cs
+++ b/NeoLua.Test/LuaType.cs
@@ -760,11 +760,25 @@ namespace LuaDLR.Test
 				Lines(
 					"local a = clr.System.Byte[];",
 					"local b = clr.System.Byte[]:GetType();",
-					"return a == b, b == a"
+					"return a == b"
 				),
-				true, true
+				true
 			);
 		}
+
+		[TestMethod]
+		public void CompareLuaTypeType02()
+		{
+			TestCode(
+				Lines(
+					"local a = clr.System.Byte[];",
+					"local b = clr.System.Byte[]:GetType();",
+					"return b == a"
+				),
+				true
+			);
+		}
+
 
 		[TestMethod]
 		public void TestTypeInitializer01()

--- a/NeoLua.Test/TestHelper.cs
+++ b/NeoLua.Test/TestHelper.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Neo.IronLua;
 
@@ -44,8 +41,8 @@ namespace LuaDLR.Test
 		public void TestExpr(string expression, params object[] expectedResult)
 			=> TestCode("return " + expression + ";", expectedResult);
 	
-		private static string FormatValue(object v)
-			=> String.Format("({0}){1}", v == null ? "object" : v.GetType().Name, v);
+		private static string FormatValue(object v) 
+			=> $"({(v == null ? "object" : v.GetType().Name)}){v}";
 
 		public static void TestResult(LuaResult result, params object[] expectedResult)
 		{
@@ -60,8 +57,9 @@ namespace LuaDLR.Test
 				}
 				else
 				{
-					Console.WriteLine("FAIL: no result != {0}", FormatValue(result[0]));
-					Assert.Fail();
+					var msg = $"FAIL: no result != {FormatValue(result[0])}";
+					Console.WriteLine(msg);
+					Assert.Fail(msg);
 				}
 			}
 			else
@@ -81,15 +79,17 @@ namespace LuaDLR.Test
 					else
 					{
 						var isOk = Equals(valueResult, valueExpected);
-						Console.WriteLine("{0}: {1} {2} {3}", isOk ? "OK" : "FAIL", FormatValue(valueResult), isOk ? "==" : "!=", FormatValue(valueExpected));
+						var msg = $"{(isOk ? "OK" : "FAIL")}: {FormatValue(valueResult)} {(isOk ? "==" : "!=")} {FormatValue(valueExpected)}";
+						Console.WriteLine(msg);
 						if (!isOk)
-							Assert.Fail();
+							Assert.Fail(msg);
 					}
 				}
 				if (result.Values.Length != expectedResult.Length)
 				{
-					Console.WriteLine("FAIL: Result Count {0} != {1}", result.Values.Length, expectedResult.Length);
-					Assert.Fail();
+					var format = $"FAIL: Result Count {result.Values.Length} != {expectedResult.Length}";
+					Console.WriteLine(format);
+					Assert.Fail(format);
 				}
 			}
 		} // proc TestResult

--- a/NeoLua/Lua.Runtime.cs
+++ b/NeoLua/Lua.Runtime.cs
@@ -258,7 +258,7 @@ namespace Neo.IronLua
 			CombineArrayWithResultMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtCombineArrayWithResult), ReflectionFlag.None, typeof(Array), typeof(LuaResult), typeof(Type));
 			ConvertArrayMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConvertArray), ReflectionFlag.None, typeof(Array), typeof(Type));
 			TableSetObjectsMethod = tiLua.FindDeclaredMethod(nameof(Lua.RtTableSetObjects), ReflectionFlag.None, typeof(LuaTable), typeof(object), typeof(int));
-			ConcatStringMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConcatString), ReflectionFlag.None | ReflectionFlag.NoArguments);
+			ConcatStringMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConcat), ReflectionFlag.None | ReflectionFlag.NoArguments);
 			ConvertDelegateMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConvertDelegate), ReflectionFlag.None | ReflectionFlag.NoArguments);
 			InitArray1MethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtInitArray), ReflectionFlag.None, typeof(Type), typeof(object));
 			InitArrayNMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtInitArray), ReflectionFlag.None, typeof(Type), typeof(object[]));

--- a/NeoLua/Lua.Runtime.cs
+++ b/NeoLua/Lua.Runtime.cs
@@ -258,7 +258,7 @@ namespace Neo.IronLua
 			CombineArrayWithResultMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtCombineArrayWithResult), ReflectionFlag.None, typeof(Array), typeof(LuaResult), typeof(Type));
 			ConvertArrayMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConvertArray), ReflectionFlag.None, typeof(Array), typeof(Type));
 			TableSetObjectsMethod = tiLua.FindDeclaredMethod(nameof(Lua.RtTableSetObjects), ReflectionFlag.None, typeof(LuaTable), typeof(object), typeof(int));
-			ConcatStringMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConcat), ReflectionFlag.None | ReflectionFlag.NoArguments);
+			ConcatStringMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConcatString), ReflectionFlag.None | ReflectionFlag.NoArguments);
 			ConvertDelegateMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtConvertDelegate), ReflectionFlag.None | ReflectionFlag.NoArguments);
 			InitArray1MethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtInitArray), ReflectionFlag.None, typeof(Type), typeof(object));
 			InitArrayNMethodInfo = tiLua.FindDeclaredMethod(nameof(Lua.RtInitArray), ReflectionFlag.None, typeof(Type), typeof(object[]));

--- a/NeoLua/LuaEmit.cs
+++ b/NeoLua/LuaEmit.cs
@@ -2244,7 +2244,7 @@ namespace Neo.IronLua
 				if (other.IsPerfect)
 				{
 					Debug.WriteLine("  ==> other IsPerfect");
-					return true;
+					return false;
 				}
 
 				if (unboundedArguments && currentParameterLength > other.currentParameterLength)
@@ -2551,7 +2551,7 @@ namespace Neo.IronLua
 			where TMEMBERTYPE : MemberInfo
 			where TARG : class
 		{
-			var unboundedArguments = callInfo.ArgumentNames.Count == 0 && arguments.Length > 0 ? getType(arguments[arguments.Length - 1]) == typeof(LuaResult) : false;
+			var unboundedArguments = callInfo.ArgumentNames.Count == 0 && arguments.Length > 0 ? arguments[arguments.Length - 1] is LuaResult { Count: > 1} : false;
 			var memberMatch = new MemberMatch<TMEMBERTYPE, TARG>(callInfo, arguments, getType);
 			var memberMatchBind = new MemberMatchInfo<TMEMBERTYPE>(unboundedArguments, arguments.Length);
 

--- a/NeoLua/LuaFile.cs
+++ b/NeoLua/LuaFile.cs
@@ -323,13 +323,13 @@ namespace Neo.IronLua
 		/// <summary></summary>
 		/// <param name="args"></param>
 		/// <returns></returns>
-		public LuaResult lines(object[] args)
+		public LuaResult lines(params object[] args)
 			=> Lua.GetEnumIteratorResult(new LuaLinesEnumerator(this, false, args, 0));
 
 		/// <summary></summary>
 		/// <param name="args"></param>
 		/// <returns></returns>
-		public LuaResult read(object[] args)
+		public LuaResult read(params object[] args)
 		{
 			if (tr == null)
 				return new LuaResult(null, Properties.Resources.rsFileNotReadable);

--- a/NeoLua/LuaLibraries.cs
+++ b/NeoLua/LuaLibraries.cs
@@ -543,7 +543,7 @@ namespace Neo.IronLua
 		/// <param name="repl"></param>
 		/// <param name="n"></param>
 		/// <returns></returns>
-		public static LuaResult gsub(this string s, string pattern, object repl, int n)
+		public static LuaResult gsub(this string s, string pattern, object repl, int? n = null)
 		{
 			var regex = new Regex(TranslateRegularExpression(pattern).Item1);
 
@@ -558,7 +558,7 @@ namespace Neo.IronLua
 			else
 				matchEvaluator = new GSubStringMatchEvaluator((string)Lua.RtConvertValue(repl, typeof(string)));
 
-			var r = regex.Replace(s, matchEvaluator.MatchEvaluator, n);
+			var r = regex.Replace(s, matchEvaluator.MatchEvaluator, n ?? Int32.MaxValue);
 
 			return new LuaResult(r, matchEvaluator.MatchCount);
 		} // func gsub

--- a/NeoLua/LuaStackTraceDebugger.cs
+++ b/NeoLua/LuaStackTraceDebugger.cs
@@ -323,7 +323,7 @@ namespace Neo.IronLua
 				// search the end
 				for (var i = startAt; i < length; i++)
 				{
-					if (debugInfos[i].MethodName != sMethodName)
+					if (debugInfos[i].MethodName != sMethodName || debugInfos[i].IsClear)
 					{
 						endAt = i - 1;
 						return true;

--- a/NeoLua/LuaTable.cs
+++ b/NeoLua/LuaTable.cs
@@ -3567,20 +3567,15 @@ namespace Neo.IronLua
 		/// <param name="t"></param>
 		/// <param name="pos"></param>
 		/// <param name="value"></param>
-		public static void insert(LuaTable t, object pos, object value)
+		public static void insert(LuaTable t, int pos, object value)
 		{
-			if (value == null && pos != null) // check for wrong overload
-				insert(t, pos);
+			// insert the value at the position
+			int index;
+			if (IsIndexKey(pos, out index) && index >= 1 && index <= t.arrayLength + 1)
+				t.ArrayOnlyInsert(index - 1, value);
 			else
-			{
-				// insert the value at the position
-				int index;
-				if (IsIndexKey(pos, out index) && index >= 1 && index <= t.arrayLength + 1)
-					t.ArrayOnlyInsert(index - 1, value);
-				else
-					t.SetValue(pos, value, true);
-			}
-		} // proc insert
+				t.SetValue(pos, value, true);
+        } // proc insert
 
 		#endregion
 
@@ -3785,7 +3780,7 @@ namespace Neo.IronLua
 		/// <param name="j"></param>
 		/// <param name="empty">Return value for empty lists</param>
 		/// <returns></returns>
-		public static T[] unpack<T>(LuaTable t, int i, int j, T[] empty)
+		private static T[] unpack<T>(LuaTable t, int i, int j, T[] empty)
 		{
 			if (j < i)
 				return empty;

--- a/NeoLua/LuaTable.cs
+++ b/NeoLua/LuaTable.cs
@@ -3763,16 +3763,16 @@ namespace Neo.IronLua
 		/// <param name="t"></param>
 		/// <param name="i"></param>
 		/// <returns></returns>
-		public static LuaResult unpack(LuaTable t, int i)
-			=> unpack(t, i, t.Length);
+		public static LuaResult unpack(LuaTable t, object i)
+			=> unpack(t, i is int index ? index : 1, t.Length);
 
 		/// <summary>Returns the elements from the given table.</summary>
 		/// <param name="t"></param>
 		/// <param name="i"></param>
 		/// <param name="j"></param>
 		/// <returns></returns>
-		public static LuaResult unpack(LuaTable t, int i, int j)
-			=> new LuaResult(LuaResult.CopyMode.None, unpack(t, i, j, LuaResult.Empty.Values));
+		public static LuaResult unpack(LuaTable t, object i, object j)
+			=> new LuaResult(LuaResult.CopyMode.None, unpack(t, i is int index ? index : 1, j is int length ? length : t.Length, LuaResult.Empty.Values));
 
 		/// <summary>Returns the elements from the given table as a sequence.</summary>
 		/// <param name="t"></param>

--- a/NeoLua/LuaType.cs
+++ b/NeoLua/LuaType.cs
@@ -189,7 +189,7 @@ namespace Neo.IronLua
 				var type = luaType;
 				var restrictions = BindingRestrictions.GetInstanceRestriction(Expression, Value);
 
-				if (type != null)
+				if (type is not null)
 				{
 					Expression result;
 					var r = LuaEmit.TrySetMember(null, type, binder.Name, binder.IgnoreCase,
@@ -522,7 +522,7 @@ namespace Neo.IronLua
 			{
 				if (String.IsNullOrEmpty(name))
 					throw new ArgumentNullException();
-				else if (parent == null)
+				else if (parent is null)
 					throw new ArgumentNullException();
 			}
 
@@ -532,9 +532,9 @@ namespace Neo.IronLua
 			this.name = name;
 
 			// set full name
-			if (parent == null)
+			if (parent is null)
 				fullName = String.Empty;
-			else if (parent.parent == null)
+			else if (parent.parent is null)
 				fullName = name;
 			else if (name[0] != '[')  // is generic type or array
 				if (parent.IsNamespace)
@@ -714,7 +714,7 @@ namespace Neo.IronLua
 		{
 			// to the root
 			var c = this;
-			while (c.parent != null && c.resolvedVersion >= 0)
+			while (c.parent is not null && c.resolvedVersion >= 0)
 			{
 				c.resolvedVersion = resolvedAsNamespace;
 				c = c.parent;
@@ -903,7 +903,7 @@ namespace Neo.IronLua
 				}
 
 				// Enum generic extensions
-				if (parent != null && parent.genericExtensionMethods != null)
+				if (parent?.genericExtensionMethods is not null)
 				{
 					MemberInfo[] copyOfExtensionMethods;
 					lock (currentTypeLock)
@@ -922,7 +922,7 @@ namespace Neo.IronLua
 			}
 
 			// Enum base members
-			if (baseType != null)
+			if (baseType is not null)
 			{
 				foreach (var c in baseType.EnumerateMembers<T>(enumeratedTypes, searchType, getDeclaredMembers))
 					yield return c;
@@ -1333,6 +1333,41 @@ namespace Neo.IronLua
 		public static implicit operator Type(LuaType type)
 			=> type?.Type;
 
+		
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="clrType"></param>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		public static bool operator ==(LuaType type, Type clrType)
+			=> type?.Type == clrType;
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="lhs"></param>
+		/// <param name="rhs"></param>
+		/// <returns></returns>
+		public static bool operator ==(LuaType lhs, LuaType rhs)
+			=> Object.ReferenceEquals(lhs, rhs);
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="lhs"></param>
+		/// <param name="rhs"></param>
+		/// <returns></returns>
+		public static bool operator !=(LuaType lhs, LuaType rhs) => !(lhs == rhs);
+
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="clrType"></param>
+		/// <param name="type"></param>
+		/// <returns></returns>
+		public static bool operator !=(LuaType type, Type clrType)
+			=> type?.Type != clrType;
 		#endregion
 
 		#region -- AddType ------------------------------------------------------------
@@ -1602,16 +1637,13 @@ namespace Neo.IronLua
 				typeName = sb.ToString();
 
 			// search the type in the cache
-			var luaType = GetCachedType(typeName);
-
 			// create the lua type
-			if (luaType == null)
-				luaType = GetType(clr, 0, typeName, ignoreCase, null);
+			var luaType = GetCachedType(typeName) ?? GetType(clr, 0, typeName, ignoreCase, null);
 
 			// Test the result
 			if (lateAllowed)
 				return luaType;
-			else if (luaType.Type != null)
+			else if (luaType.Type is not null)
 				return luaType;
 			else
 				return null;
@@ -1674,7 +1706,7 @@ namespace Neo.IronLua
 						if (currentType.IsGenericParameter)
 							continue; // we do not support generic types
 
-						if (lastType == null || currentType != lastType.Type)
+						if (lastType is null || currentType != lastType.Type)
 							lastType = GetType(currentType);
 
 						// register the method

--- a/NeoLua/NeoLua.csproj
+++ b/NeoLua/NeoLua.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
 		<AssemblyName>Neo.Lua</AssemblyName>
 		<RootNamespace>Neo.IronLua</RootNamespace>
-		<TargetFrameworks>net451;net48;netstandard2.0;netcoreapp2.1;net6.0</TargetFrameworks>
+		<TargetFrameworks>net451;net48;netstandard2.0;net6.0</TargetFrameworks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Description>A Lua implementation for the Dynamic Language Runtime (DLR).</Description>
 		<PackageId>NeoLua</PackageId>

--- a/NeoLua/Parser.Emit.cs
+++ b/NeoLua/Parser.Emit.cs
@@ -30,6 +30,7 @@ namespace Neo.IronLua
 
 	///////////////////////////////////////////////////////////////////////////////
 	/// <summary></summary>
+	[Flags]
 	internal enum ReflectionFlag
 	{
 		None = 0,
@@ -351,7 +352,7 @@ namespace Neo.IronLua
 			MethodInfo mi;
 			ConstantExpression constInstance = instance as ConstantExpression;
 			LuaType t;
-			if (constInstance != null && (t = constInstance.Value as LuaType) != null && t.Type != null) // we have a type, bind the ctor
+			if (constInstance is not null && (t = constInstance.Value as LuaType) is not null && t.Type is not null) // we have a type, bind the ctor
 			{
 				var type = t.Type;
 				var typeInfo = type.GetTypeInfo();
@@ -384,7 +385,7 @@ namespace Neo.IronLua
 				);
 			}
 			else if (typeof(Delegate).GetTypeInfo().IsAssignableFrom(instance.Type.GetTypeInfo()) &&  // test if the type is assignable from delegate
-				(mi = instance.Type.GetRuntimeMethods().Where(c => !c.IsStatic && c.IsPublic && c.Name == "Invoke").FirstOrDefault()) != null) // Search the Invoke method for the arguments
+				(mi = instance.Type.GetRuntimeMethods().Where(c => !c.IsStatic && c.IsPublic && c.Name == "Invoke").FirstOrDefault()) is not null) // Search the Invoke method for the arguments
 			{
 				return EnsureInvokeResult(scope, tStart,
 					SafeExpression(() => LuaEmit.BindParameter<Expression>(

--- a/NeoLua/Parser.cs
+++ b/NeoLua/Parser.cs
@@ -87,7 +87,7 @@ namespace Neo.IronLua
 
 			private void RegisterVariableOrConst(string name, Expression expr)
 			{
-				if (scopeVariables == null)
+				if (scopeVariables is null)
 					scopeVariables = new Dictionary<string, Expression>();
 				scopeVariables[name] = expr;
 			} // proc EnsureVariables
@@ -156,7 +156,7 @@ namespace Neo.IronLua
 						var variables = Variables;
 						if (variables.Length == 0)
 							return Expression.Block(block);
-						else if (ExpressionBlockType == null)
+						else if (ExpressionBlockType is null)
 							return Expression.Block(variables, block);
 						else
 							return Expression.Block(ExpressionBlockType, variables, block);
@@ -180,7 +180,7 @@ namespace Neo.IronLua
 			/// <summary>Return type of the current Lambda-Scope</summary>
 			public virtual Type ReturnType => parent.ReturnType;
 			/// <summary></summary>
-			public ParameterExpression[] Variables => scopeVariables == null ? new ParameterExpression[0] : (from v in scopeVariables.Values where v is ParameterExpression select (ParameterExpression)v).ToArray();
+			public ParameterExpression[] Variables => scopeVariables is null ? new ParameterExpression[0] : (from v in scopeVariables.Values where v is ParameterExpression select (ParameterExpression)v).ToArray();
 
 			public virtual bool ActivateRethrow => parent != null && parent.ActivateRethrow;
 		} // class Scope
@@ -291,9 +291,9 @@ namespace Neo.IronLua
 			{
 				if (name == csReturnLabel)
 					return returnLabel;
-				if (labels == null)
+				if (labels is null)
 					labels = new Dictionary<string, LabelTarget>();
-				if (type == null)
+				if (type is null)
 					type = typeof(void);
 
 				// Lookup the label
@@ -323,7 +323,7 @@ namespace Neo.IronLua
 			{
 				get
 				{
-					AddExpression(Expression.Label(returnLabel, returnDefaultValue == null ? Expression.Default(returnLabel.Type) : returnDefaultValue));
+					AddExpression(Expression.Label(returnLabel, returnDefaultValue is null ? Expression.Default(returnLabel.Type) : returnDefaultValue));
 					return base.ExpressionBlock;
 				}
 			} // prop ExpressionBlock
@@ -363,7 +363,7 @@ namespace Neo.IronLua
 			{
 				this.runtime = runtime;
 				this.options = options;
-				this.debug = options.DebugEngine == null ? LuaDebugLevel.None : options.DebugEngine.Level;
+				this.debug = options.DebugEngine is null ? LuaDebugLevel.None : options.DebugEngine.Level;
 			} // ctor
 
 			/// <summary>Access to the binders</summary>
@@ -483,11 +483,11 @@ namespace Neo.IronLua
 			public Expression GenerateSet(Scope scope, Expression exprToSet)
 			{
 				Expression expr;
-				if (Instance != null && Member == null && Indices != null && Arguments == null)
+				if (Instance != null && Member is null && Indices != null && Arguments is null)
 					expr = IndexSetExpression(scope.Runtime, Position, Instance, Indices, exprToSet);
-				else if (Instance != null && Member != null && Indices == null && Arguments == null)
+				else if (Instance != null && Member != null && Indices is null && Arguments is null)
 					return MemberSetExpression(scope.Runtime, Position, Instance, Member, MethodMember, exprToSet);
-				else if (Instance != null && Member == null && Indices == null && Arguments == null && Instance is ParameterExpression)
+				else if (Instance != null && Member is null && Indices is null && Arguments is null && Instance is ParameterExpression)
 				{
 					// Assign the value to a variable
 					expr = Expression.Assign(Instance, ConvertExpression(scope.Runtime, Position, exprToSet, Instance.Type));
@@ -500,7 +500,7 @@ namespace Neo.IronLua
 
 			public Expression GenerateGet(Scope scope, InvokeResult result)
 			{
-				if (Instance != null && Member == null && Indices != null && Arguments == null)
+				if (Instance != null && Member is null && Indices != null && Arguments is null)
 				{
 					if (Indices.Length > 0)
 					{
@@ -511,7 +511,7 @@ namespace Neo.IronLua
 					Instance = IndexGetExpression(scope, Position, Instance, Indices);
 					Indices = null;
 				}
-				else if (Instance != null && Member != null && Indices == null && Arguments == null && !MethodMember)
+				else if (Instance != null && Member != null && Indices is null && Arguments is null && !MethodMember)
 				{
 					// Convert the member to an instance
 					Instance = WrapDebugInfo(scope.EmitExpressionDebug, true, Position, Position, Instance);
@@ -519,11 +519,11 @@ namespace Neo.IronLua
 					Member = null;
 					MethodMember = false;
 				}
-				else if (Instance != null && Member == null && Indices == null && Arguments == null)
+				else if (Instance != null && Member is null && Indices is null && Arguments is null)
 				{
 					// Nothing to todo, we have already an instance
 				}
-				else if (Instance != null && Indices == null && (Arguments != null || MethodMember))
+				else if (Instance != null && Indices is null && (Arguments != null || MethodMember))
 				{
 					Arguments = Arguments ?? new ArgumentsList();
 					if (Arguments.Count > 0)
@@ -580,7 +580,7 @@ namespace Neo.IronLua
 		public static LambdaExpression ParseChunk(Lua runtime, LuaCompileOptions options, bool hasEnvironment, ILuaLexer code, Type typeDelegate, Type returnType, IEnumerable<KeyValuePair<string, Type>> args)
 		{
 			var parameters = new List<ParameterExpression>();
-			if (returnType == null)
+			if (returnType is null)
 				returnType = typeof(LuaResult);
 			var globalScope = new GlobalScope(runtime, options, returnType, returnType == typeof(LuaResult) ? Expression.Property(null, Lua.ResultEmptyPropertyInfo) : null);
 
@@ -600,7 +600,7 @@ namespace Neo.IronLua
 			}
 
 			// Get the first token
-			if (code.Current == null)
+			if (code.Current is null)
 				code.Next();
 
 			// Get the name for the chunk and clean it from all unwanted chars
@@ -615,7 +615,7 @@ namespace Neo.IronLua
 				throw ParseError(code.Current, Properties.Resources.rsParseEof);
 
 			// Create the function
-			return typeDelegate == null ?
+			return typeDelegate is null ?
 				Expression.Lambda(globalScope.ExpressionBlock, chunkName, parameters) :
 				Expression.Lambda(typeDelegate, globalScope.ExpressionBlock, chunkName, parameters);
 		} // func ParseChunk
@@ -880,10 +880,10 @@ namespace Neo.IronLua
 					ParseIdentifierAndType(scope, code, out var tVar, out var typeVar);
 
 					var exprVar = scope.LookupExpression(tVar.Value, true) as ParameterExpression;
-					if (exprVar == null)
+					if (exprVar is null)
 					{
 						exprVar = Expression.Variable(typeVar, tVar.Value);
-						if (registerLocals == null)
+						if (registerLocals is null)
 							registerLocals = new List<ParameterExpression>();
 						registerLocals.Add(exprVar);
 					}
@@ -921,7 +921,7 @@ namespace Neo.IronLua
 							prefixes[0].GenerateSet(scope, expr.Current ?? Expression.Constant(null, typeof(object)))
 						);
 					}
-					else if (expr.Current == null) // No expression, assign null
+					else if (expr.Current is null) // No expression, assign null
 					{
 						for (var i = 0; i < prefixes.Count; i++)
 							scope.AddExpression(prefixes[i].GenerateSet(scope, Expression.Constant(null, typeof(object))));
@@ -1000,7 +1000,7 @@ namespace Neo.IronLua
 			{
 				for (var i = 0; i < prefixes.Count; i++)
 				{
-					if (prefixes[i].Arguments == null) // do not execute getMember
+					if (prefixes[i].Arguments is null) // do not execute getMember
 						throw ParseError(prefixes[i].Position, Properties.Resources.rsParseAssignmentExpected);
 
 					scope.AddExpression(prefixes[i].GenerateGet(scope, InvokeResult.None));
@@ -1094,7 +1094,7 @@ namespace Neo.IronLua
 					try
 					{
 						var r = EvaluateExpression(exprConst);
-						if (r == null) // Eval via compile
+						if (r is null) // Eval via compile
 						{
 							var typeFunc = Expression.GetFuncType(exprConst.Type);
 							var exprEval = Expression.Lambda(typeFunc, exprConst);
@@ -1169,10 +1169,10 @@ namespace Neo.IronLua
 						else
 							memberName = t.Value;
 						var p = scope.LookupExpression(memberName);
-						if (t.Typ == LuaToken.DotDotDot && p == null)
+						if (t.Typ == LuaToken.DotDotDot && p is null)
 							throw ParseError(t, Properties.Resources.rsParseNoArgList);
 						code.Next();
-						if (p == null) // No local variable found
+						if (p is null) // No local variable found
 							info = new PrefixMemberInfo(tStart, scope.LookupExpression(csEnv), t.Value, null, null);
 						else
 							info = new PrefixMemberInfo(tStart, p, null, null, null);
@@ -1318,7 +1318,7 @@ namespace Neo.IronLua
 				var tFirst = code.Current;
 				var expr = ParseExpression(scope, code, InvokeResult.LuaResult, scope.EmitExpressionDebug);
 
-				if (tName == null)
+				if (tName is null)
 					argumentsList.AddPositionalArgument(tFirst, expr);
 				else
 					argumentsList.AddNamedArgument(tName, expr);
@@ -1714,7 +1714,7 @@ namespace Neo.IronLua
 
 					if (genericeTypes.Count == 0) // create a array at the end
 					{
-						if (currentType.Type == null)
+						if (currentType.Type is null)
 							throw ParseError(code.Current, String.Format(Properties.Resources.rsParseUnknownType, currentType.FullName));
 
 						currentType = LuaType.GetType(currentType.AddType("[]", false, 1));
@@ -1738,7 +1738,7 @@ namespace Neo.IronLua
 				}
 			}
 
-			if (needType && currentType.Type == null)
+			if (needType && currentType.Type is null)
 				throw ParseError(code.Current, String.Format(Properties.Resources.rsParseUnknownType, currentType.FullName));
 
 			return currentType;
@@ -1748,7 +1748,7 @@ namespace Neo.IronLua
 		{
 			var typeName = FetchToken(LuaToken.Identifier, code).Value;
 			var luaType = LuaType.GetCachedType(typeName);
-			if (luaType == null)
+			if (luaType is null)
 			{
 				return scope.LookupExpression(typeName, false) is ConstantExpression cexpr && cexpr.Type == typeof(LuaType)
 					? (LuaType)cexpr.Value
@@ -2194,7 +2194,7 @@ namespace Neo.IronLua
 
 				var funcVar = scope.LookupExpression(t.Value) as ParameterExpression;
 				Expression exprFunction;
-				if (funcVar == null)
+				if (funcVar is null)
 				{
 					exprFunction = ParseLamdaDefinition(scope, code, t.Value, false,
 						typeDelegate => funcVar = scope.RegisterVariable(typeDelegate, t.Value)
@@ -2234,7 +2234,7 @@ namespace Neo.IronLua
 				}
 				else
 				{
-					if (assignee == null)
+					if (assignee is null)
 					{
 						// there was no member access, so try to find a local to assign to
 						var local = scope.LookupExpression(memberName);
@@ -2255,10 +2255,10 @@ namespace Neo.IronLua
 
 		private static Expression ParseFunctionAddChain(Scope scope, Token tStart, Expression assignee, string memberName)
 		{
-			if (assignee == null)
+			if (assignee is null)
 			{
 				var expr = scope.LookupExpression(memberName);
-				if (expr == null)
+				if (expr is null)
 					assignee = ParseFunctionAddChain(scope, tStart, scope.LookupExpression(csEnv), memberName);
 				else
 					assignee = expr;
@@ -2503,7 +2503,7 @@ namespace Neo.IronLua
 
 		public static string ExpressionToString(Expression expr)
 		{
-			if (propertyDebugView == null)
+			if (propertyDebugView is null)
 				propertyDebugView = typeof(Expression).GetTypeInfo().FindDeclaredProperty("DebugView", ReflectionFlag.NoException | ReflectionFlag.NonPublic | ReflectionFlag.Instance);
 
 			return (string)propertyDebugView.GetValue(expr, null);

--- a/NeoLua/TypeExtensionHelpers.cs
+++ b/NeoLua/TypeExtensionHelpers.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Neo.IronLua
+{
+	static class TypeExtensionHelpers
+	{
+	public static bool HasImplicitConversionToType(this Type declaringType, Type targetType)
+	{
+		return declaringType.TryGetImplicitAssignmentOperatorToType(targetType, out _);
+	}
+
+	public static bool HasImplicitConversionFromType(this Type declaringType, Type sourceType)
+	{
+		return declaringType.TryGetImplicitAssignmentOperatorFromType(sourceType, out _);
+	}
+
+	public static bool CanConvertTo(this Type sourceType, Type targetType)
+	{
+		Debug.Assert(targetType != sourceType);
+		return GetAllImplicitOperators(sourceType).Any(CanImplicitlyCastToTarget);
+
+		bool CanImplicitlyCastToTarget(MethodInfo mi)
+		{
+			var parameterInfos = mi.GetParameters();
+			Debug.Assert(parameterInfos[0].ParameterType == sourceType);
+			var canConvertTo = CanAssign(mi.ReturnType, targetType);
+			return canConvertTo;
+		}
+	}
+
+	/// <summary>
+	/// True if the source type can be converted to the target type.
+	/// </summary>
+	/// <param name="targetType"></param>
+	/// <param name="sourceType"></param>
+	/// <returns></returns>
+	public static bool CanConvertFrom(this Type targetType, Type sourceType)
+	{
+		Debug.Assert(targetType != sourceType);
+		return GetAllImplicitOperators(targetType).Any(CanImplicitlyConstructFromSource);
+
+		bool CanImplicitlyConstructFromSource(MethodInfo mi)
+		{
+			var parameterInfos = mi.GetParameters();
+			var parameterType = parameterInfos[0].ParameterType;
+			var canConvertTo = CanAssign(sourceType, parameterType);
+			return canConvertTo;
+		}
+	}
+
+	public static bool CanAssignFromPrimitiveType(this Type targetType, Type sourceType)
+	{
+		return CanAssignValueType(sourceType, targetType);
+	}
+
+	private static bool CanAssign(Type from, Type to)
+	{
+		if (from == to) return true;
+		if (from.IsAssignableFrom(to)) return true;
+		if (from.IsValueType && to.IsValueType && CanAssignValueType(from, to)) return true;
+
+		return false;
+	}
+
+	static bool TryGetImplicitAssignmentOperatorToType(this Type declaringType, Type toType, out MethodInfo implicitOperator)
+	{
+		Debug.Assert(declaringType != toType);
+		implicitOperator = declaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+			.FirstOrDefault(mi => mi.Name == "op_Implicit" && mi.ReturnType == toType);
+		if (implicitOperator is not null)
+		{
+			Debug.Assert(implicitOperator.GetParameters()[0].ParameterType == declaringType);
+			return true;
+		}
+
+		return false;
+	}
+
+	static bool TryGetImplicitAssignmentOperatorFromType(this Type declaringType, Type fromType, out MethodInfo implicitOperator)
+	{
+		Debug.Assert(declaringType != fromType);
+		// There can only be a single implicit operator from a type
+		var op = GetImplicitOperator(declaringType, fromType);
+		if (op is not null)
+		{
+			Debug.Assert(op.ReturnType == declaringType);
+			implicitOperator = op;
+			return true;
+		}
+
+		implicitOperator = null;
+		return false;
+	}
+
+	static MethodInfo[] GetImplicitOperatorsToType(Type declaringType) =>
+		declaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+			.Where(mi => mi.Name == "op_Implicit" && mi.ReturnType == declaringType).ToArray();
+
+
+	static MethodInfo GetImplicitOperator(Type declaringType, Type fromType)
+	{
+		return declaringType.GetMethod("op_Implicit", BindingFlags.Public | BindingFlags.Static, binder: null,
+			new[] { fromType }, EmptyParameterModifier);
+	}
+
+	static IEnumerable<MethodInfo> GetAllImplicitOperators(Type declaringType)
+	{
+		return declaringType.GetMethods(BindingFlags.Public | BindingFlags.Static)
+			.Where(mi => mi.Name == "op_ImplicitO");
+	}
+
+		private static ParameterModifier[] EmptyParameterModifier = new ParameterModifier[0];
+
+	static bool CanAssignValueType(Type argType, Type parameterType)
+	{
+		if (argType == typeof(Int16))
+			return parameterType == typeof(Int16) || parameterType == typeof(Int32) || parameterType == typeof(Int64)
+				   || parameterType == typeof(Single) || parameterType == typeof(Double);
+		if (argType == typeof(Int32))
+			return parameterType == typeof(Int32) || parameterType == typeof(Int64) || parameterType == typeof(Single) ||  parameterType == typeof(Double);
+		if (argType == typeof(Int64))
+			return parameterType == typeof(Int64) || parameterType == typeof(Double);
+
+		if (argType == typeof(Single))
+			return parameterType == typeof(Single) || parameterType == typeof(Double);
+		if (argType == typeof(Double)) return parameterType == typeof(Double);
+		return false;
+	}
+
+	public static bool IsParamArray(this ParameterInfo parameterInfo) => parameterInfo.GetCustomAttribute(typeof(ParamArrayAttribute), false) is not null;
+	}
+}


### PR DESCRIPTION
Reworking how FindMethod works.

There are for sure some cleanup that could be done, but now all test cases pass.

I've also added new specific tests for FindMethod in LuaEmitTests.cs.

High level changes are to make FindMethod first filter members to only include valid overloads, and then pass them to the next stage where the best match is determined.

This is done by using penalties for different kinds of conversion, where the method with the lowest penalty is selected.
The algorithm can surely be improved.

