### PR TITLE
Improving debugging with DebuggerProxy for LuaTable and LuaTraceLineEventArgs

### DIFF
--- a/NeoLua.Dbg/LuaTraceLineDebugger.cs
+++ b/NeoLua.Dbg/LuaTraceLineDebugger.cs
@@ -21,6 +21,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.Scripting;
@@ -31,7 +32,10 @@ namespace Neo.IronLua
 {
 	#region -- class LuaTraceLineEventArgs ----------------------------------------------
 
+	
 	/// <summary></summary>
+	[DebuggerDisplay("{DebuggerDisplay, nq}")]
+	[DebuggerTypeProxy(typeof(LuaTraceLineEventArgsDebuggerProxy))]
 	public class LuaTraceLineEventArgs : EventArgs
 	{
 		private readonly string name;
@@ -57,6 +61,37 @@ namespace Neo.IronLua
 
 		/// <summary></summary>
 		public IDictionary<object, object> Locals => locals.Value;
+
+		private string DebuggerDisplay => $"{SourceName}:{SourceLine} {ScopeName}";
+
+		class LuaTraceLineEventArgsDebuggerProxy
+		{
+			private readonly LuaTraceLineEventArgs eventArgs;
+		    private KeyValuePair<string, object>[] locals;
+
+		    public LuaTraceLineEventArgsDebuggerProxy(LuaTraceLineEventArgs eventArgs)
+		    {
+		        this.eventArgs = eventArgs;
+		        var eventLocals = eventArgs.Locals;
+		    }
+
+
+		    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+		    public KeyValuePair<string, object>[] Locals => locals ??= GetLocals();
+
+		    private KeyValuePair<string, object>[] GetLocals()
+		    {
+		        var eventArgsLocals = eventArgs.Locals;
+		        KeyValuePair<string, object>[] locals = new KeyValuePair<string, object>[eventArgsLocals.Count];
+		        int i = 0;
+		        foreach (var kv in eventArgsLocals)
+		        {
+		            locals[i++] = new KeyValuePair<string, object>(kv.Key.ToString()!, kv.Value);
+		        }
+
+		        return locals;
+		    }
+		}
 	} // class LuaTraceLineEventArgs
 
 	#endregion
@@ -64,6 +99,8 @@ namespace Neo.IronLua
 	#region -- class LuaTraceLineExceptionEventArgs -------------------------------------
 
 	/// <summary></summary>
+
+	[DebuggerDisplay("{DebuggerDisplay,nq}")]
 	public class LuaTraceLineExceptionEventArgs : LuaTraceLineEventArgs
 	{
 		private readonly Exception exception;
@@ -76,6 +113,8 @@ namespace Neo.IronLua
 
 		/// <summary></summary>
 		public Exception Exception => exception;
+
+		private string DebuggerDisplay => $"{SourceName}:{SourceLine} {ScopeName} - {Exception.Message}";
 	} // class LuaTraceLineExceptionEventArgs
 
 	#endregion

--- a/NeoLua.Dbg/NeoLua.Dbg.csproj
+++ b/NeoLua.Dbg/NeoLua.Dbg.csproj
@@ -11,6 +11,7 @@
 		<Description>A Lua implementation for the Dynamic Language Runtime (DLR). Debug-Extension.</Description>
 		<PackageTags>Lua C# .net DLR Dynamic Language Debug</PackageTags>
 		<NeutralLanguage></NeutralLanguage>
+		<LangVersion>9</LangVersion>
 	</PropertyGroup>
 	<Import Project="..\NeoLua.NuGet\common.nupkg.targets" />
 	<ItemGroup>

--- a/NeoLua/LuaEmit.cs
+++ b/NeoLua/LuaEmit.cs
@@ -2664,7 +2664,7 @@ namespace Neo.IronLua
 				}
 			}
 #else
-			var filteredMembers = members.Where(c => IsMemberCandidate(c, arguments, isMemberCall));
+			var filteredMembers = candidateOverloads.Where(c => IsMemberCandidate(c, arguments, isMemberCall));
 #endif
 			return filteredMembers.Distinct();
 		}


### PR DESCRIPTION
This makes it easier to debug tables and gives a view like the following:

<img width="479" alt="image" src="https://github.com/neolithos/neolua/assets/3505151/33ba6989-feb5-4b26-a170-eb0105921f4d">
