### PR TITLE
Fix select() to correctly convert 1-based Lua index to 0-based CLR index

### DIFF
--- a/NeoLua.Test/Functions.cs
+++ b/NeoLua.Test/Functions.cs
@@ -440,5 +440,32 @@ return f()
 			}
 		}
 
+		[TestMethod]
+		public void TestSelectIndexConversion()
+		{
+			// select(1, ...) should return the first argument (Lua uses 1-based indexing)
+			TestCode(Lines(
+				"return select(1, 'a', 'b', 'c');"),
+				"a", "b", "c");
+		}
+
+		[TestMethod]
+		public void TestSelectIndexConversion02()
+		{
+			// select(2, ...) should skip the first argument and return from the second onward
+			TestCode(Lines(
+				"return select(2, 'a', 'b', 'c');"),
+				"b", "c");
+		}
+
+		[TestMethod]
+		public void TestSelectIndexConversion03()
+		{
+			// select(3, ...) on three args should return only the third element
+			TestCode(Lines(
+				"return select(3, 10, 20, 30);"),
+				30);
+		}
+
 	} // class Functions
 }

--- a/NeoLua/LuaGlobal.cs
+++ b/NeoLua/LuaGlobal.cs
@@ -617,6 +617,10 @@ namespace Neo.IronLua
 					if (idx < 0)
 						idx = 0;
 				}
+				else if (idx > 0)
+				{
+					idx--; // convert 1-based Lua index to 0-based CLR array index
+				}
 				if (idx < values.Length)
 				{
 					var r = new object[values.Length - idx];


### PR DESCRIPTION
## Problem

The built-in `select(index, ...)` function did not correctly handle Lua's 1-based indexing when using positive indices. In Lua, `select(1, 'a', 'b', 'c')` should return all arguments starting from the first, but NeoLua was treating the index as 0-based (CLR-style), causing an off-by-one error.

For example:
- `select(1, 'a', 'b', 'c')` returned `'b', 'c'` instead of `'a', 'b', 'c'`
- `select(2, 'a', 'b', 'c')` returned `'c'` instead of `'b', 'c'`
- `select(3, 10, 20, 30)` returned empty instead of `30`

## Fix

In `LuaGlobal.LuaSelect`, positive indices are now decremented by 1 to convert from Lua's 1-based indexing to the 0-based CLR array index. Negative indices (which count from the end) were already handled correctly.

## Tests

Added three test cases in `Functions.cs` that validate `select()` with positive indices:
- `TestSelectIndexConversion` — `select(1, ...)` returns all values
- `TestSelectIndexConversion02` — `select(2, ...)` skips the first value
- `TestSelectIndexConversion03` — `select(3, ...)` returns only the last value